### PR TITLE
Fold unchanged regions in the unified diff

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
@@ -148,6 +148,8 @@ public final class CompareMessages extends NLS {
 	public static String UnifiedDiff_openTwoWayCompare_tooltip;
 	public static String UnifiedDiff_cannotEditFile_title;
 	public static String UnifiedDiff_cannotEditFile_message;
+	public static String UnifiedDiff_expandUnchangedLine;
+	public static String UnifiedDiff_expandUnchangedLines;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, CompareMessages.class);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
@@ -137,6 +137,10 @@ public final class CompareMessages extends NLS {
 	public static String UnifiedDiff_openTwoWayCompare_tooltip;
 	public static String UnifiedDiff_preparing;
 	public static String UnifiedDiff_computing;
+	public static String UnifiedDiff_showUnchangedLine;
+	public static String UnifiedDiff_showUnchangedLines;
+	public static String UnifiedDiff_hideUnchangedLine;
+	public static String UnifiedDiff_hideUnchangedLines;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, CompareMessages.class);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
@@ -163,3 +163,5 @@ UnifiedDiff_revert=Revert
 UnifiedDiff_openTwoWayCompare_tooltip=Open in 2-way Compare Editor
 UnifiedDiff_cannotEditFile_title=Cannot edit file
 UnifiedDiff_cannotEditFile_message=Cannot edit file {0}: {1}
+UnifiedDiff_expandUnchangedLine=Expand 1 unchanged line
+UnifiedDiff_expandUnchangedLines=Expand {0} unchanged lines

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
@@ -152,3 +152,7 @@ UnifiedDiff_revert=Revert
 UnifiedDiff_openTwoWayCompare_tooltip=Open in 2-way Compare Editor
 UnifiedDiff_preparing=Preparing Unified Diff for {0}
 UnifiedDiff_computing=Computing Unified Diff
+UnifiedDiff_showUnchangedLine=Show 1 unchanged line
+UnifiedDiff_showUnchangedLines=Show {0} unchanged lines
+UnifiedDiff_hideUnchangedLine=Hide 1 unchanged line
+UnifiedDiff_hideUnchangedLines=Hide {0} unchanged lines

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ComparePreferencePage.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ComparePreferencePage.java
@@ -50,6 +50,7 @@ import org.eclipse.swt.layout.TabFolderLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbench;
@@ -124,6 +125,7 @@ public class ComparePreferencePage extends PreferencePage implements IWorkbenchP
 	public static final String REMOVED_LINES_REGEX= PREFIX + "RemovedLinesRegex"; //$NON-NLS-1$
 	public static final String SWAPPED = PREFIX + "Swapped"; //$NON-NLS-1$
 	public static final String UNIFIED_DIFF = PREFIX + "UnifiedDiff"; //$NON-NLS-1$
+	public static final String UNIFIED_DIFF_FOLD_UNCHANGED = PREFIX + "UnifiedDiffFoldUnchanged"; //$NON-NLS-1$
 
 
 	private IPropertyChangeListener fPreferenceChangeListener;
@@ -156,6 +158,7 @@ public class ComparePreferencePage extends PreferencePage implements IWorkbenchP
 		new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.STRING, ICompareUIConstants.PREF_NAVIGATION_END_ACTION_LOCAL),
 		new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, SWAPPED),
 		new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, UNIFIED_DIFF),
+		new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, UNIFIED_DIFF_FOLD_UNCHANGED),
 	};
 	private final List<FieldEditor> editors = new ArrayList<>();
 	private CTabItem fTextCompareTab;
@@ -180,6 +183,7 @@ public class ComparePreferencePage extends PreferencePage implements IWorkbenchP
 		store.setDefault(ICompareUIConstants.PREF_NAVIGATION_END_ACTION_LOCAL, ICompareUIConstants.PREF_VALUE_LOOP);
 		store.setDefault(SWAPPED, true);
 		store.setDefault(UNIFIED_DIFF, false);
+		store.setDefault(UNIFIED_DIFF_FOLD_UNCHANGED, true);
 	}
 
 	public ComparePreferencePage() {
@@ -289,7 +293,14 @@ public class ComparePreferencePage extends PreferencePage implements IWorkbenchP
 		addCheckBox(composite, "ComparePreferencePage.structureCompare.label", OPEN_STRUCTURE_COMPARE, 0);	//$NON-NLS-1$
 		addCheckBox(composite, "ComparePreferencePage.structureOutline.label", USE_OUTLINE_VIEW, 0);	//$NON-NLS-1$
 		addCheckBox(composite, "ComparePreferencePage.ignoreWhitespace.label", IGNORE_WHITESPACE, 0);	//$NON-NLS-1$
-		addCheckBox(composite, "ComparePreferencePage.unifiedDiff.label", UNIFIED_DIFF, 0); //$NON-NLS-1$
+		Group unifiedDiffGroup= new Group(composite, SWT.NONE);
+		unifiedDiffGroup.setText(Utilities.getString("ComparePreferencePage.unifiedDiffGroup.label")); //$NON-NLS-1$
+		unifiedDiffGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		unifiedDiffGroup.setLayout(new GridLayout(1, false));
+
+		addCheckBox(unifiedDiffGroup, "ComparePreferencePage.unifiedDiff.label", UNIFIED_DIFF, 0); //$NON-NLS-1$
+		addCheckBox(unifiedDiffGroup, "ComparePreferencePage.unifiedDiffFoldUnchanged.label", //$NON-NLS-1$
+				UNIFIED_DIFF_FOLD_UNCHANGED, 0);
 
 		// a spacer
 		new Label(composite, SWT.NONE);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -263,6 +263,10 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 
 	public static final int NO_DIFFERENCE = 10000;
 
+	// Number of unchanged context lines kept around each change when the unified
+	// diff collapses unchanged regions.
+	private static final int UNIFIED_DIFF_CONTEXT_LINES = 3;
+
 	/**
 	 * The plugin singleton.
 	 */
@@ -627,6 +631,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 										: null)
 								.ignoreWhiteSpace(Utilities.getBoolean(input.getCompareConfiguration(),
 										CompareConfiguration.IGNORE_WHITESPACE, false))
+								.foldUnchanged(UNIFIED_DIFF_CONTEXT_LINES)
 								.open();
 						return status.isOK();
 					}
@@ -654,6 +659,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 										: null)
 								.ignoreWhiteSpace(Utilities.getBoolean(input.getCompareConfiguration(),
 										CompareConfiguration.IGNORE_WHITESPACE, false))
+								.foldUnchanged(UNIFIED_DIFF_CONTEXT_LINES)
 								.open();
 						return status.isOK();
 					}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -314,6 +314,10 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 
 	public static final int NO_DIFFERENCE = 10000;
 
+	// Number of unchanged context lines kept around each change when the unified
+	// diff collapses unchanged regions.
+	private static final int UNIFIED_DIFF_CONTEXT_LINES = 3;
+
 	/**
 	 * The plugin singleton.
 	 */
@@ -633,6 +637,13 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 		openClassicCompareEditor(input, page, editor, activate);
 	}
 
+	/** The context lines to keep, or a negative value when folding is turned off. */
+	private static int foldUnchangedContextLines() {
+		return getDefault().getPreferenceStore().getBoolean(ComparePreferencePage.UNIFIED_DIFF_FOLD_UNCHANGED)
+				? UNIFIED_DIFF_CONTEXT_LINES
+				: -1;
+	}
+
 	/** Opens the classic side by side compare editor on the given input. */
 	private void openClassicCompareEditor(final CompareEditorInput input, final IWorkbenchPage page,
 			final IReusableEditor editor, final boolean activate) {
@@ -736,6 +747,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 					.tokenComparatorFactory(t -> mergerInput != null ? mergerInput.createTokenComparator(t) : null)
 					.ignoreWhiteSpace(Utilities.getBoolean(input.getCompareConfiguration(),
 							CompareConfiguration.IGNORE_WHITESPACE, false))
+					.foldUnchanged(foldUnchangedContextLines())
 					.open();
 			// The user canceled the diff, not the open: leave the text editor alone
 			// instead of falling back to the classic compare editor.

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/UnifiedDiff.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/UnifiedDiff.java
@@ -62,6 +62,7 @@ public final class UnifiedDiff {
 		private List<Action> additionalActions;
 		private TokenComparatorFactory tokenComparatorFactory;
 		private IgnoreWhitespaceContributorFactory ignoreWhitespaceContributorFactory;
+		private int foldContextLines = -1;
 
 		private Builder(ITextEditor editor, String source, UnifiedDiffMode mode) {
 			this.editor = Objects.requireNonNull(editor, "Editor cannot be null"); //$NON-NLS-1$
@@ -89,9 +90,19 @@ public final class UnifiedDiff {
 			return this;
 		}
 
+		/**
+		 * Collapses unchanged regions between diffs, keeping the given number of
+		 * context lines (at least one) around each change. A negative value disables
+		 * folding.
+		 */
+		public Builder foldUnchanged(int contextLines) {
+			this.foldContextLines = contextLines;
+			return this;
+		}
+
 		public IStatus open() {
 			return UnifiedDiffManager.open(editor, source, mode, additionalActions, tokenComparatorFactory,
-					ignoreWhitespaceContributorFactory, ignoreWhiteSpace);
+					ignoreWhitespaceContributorFactory, ignoreWhiteSpace, foldContextLines);
 		}
 	}
 }

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/UnifiedDiff.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/UnifiedDiff.java
@@ -62,6 +62,7 @@ public final class UnifiedDiff {
 		private List<Action> additionalActions;
 		private TokenComparatorFactory tokenComparatorFactory;
 		private IgnoreWhitespaceContributorFactory ignoreWhitespaceContributorFactory;
+		private int foldContextLines = -1;
 
 		private Builder(ITextEditor editor, String source, UnifiedDiffMode mode) {
 			this.editor = Objects.requireNonNull(editor, "Editor cannot be null"); //$NON-NLS-1$
@@ -89,9 +90,23 @@ public final class UnifiedDiff {
 			return this;
 		}
 
+		/**
+		 * Collapses unchanged regions between diffs, keeping the given number of
+		 * context lines (at least one) around each change. A negative value disables
+		 * folding.
+		 * <p>
+		 * The folding of the editor is reused, so this has no effect in an editor
+		 * without folding support, such as the default text editor, or in an editor
+		 * whose folding the user turned off.
+		 */
+		public Builder foldUnchanged(int contextLines) {
+			this.foldContextLines = contextLines;
+			return this;
+		}
+
 		public IStatus open() {
 			return UnifiedDiffManager.open(editor, source, mode, additionalActions, tokenComparatorFactory,
-					ignoreWhitespaceContributorFactory, ignoreWhiteSpace);
+					ignoreWhitespaceContributorFactory, ignoreWhiteSpace, foldContextLines);
 		}
 	}
 }

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffCodeMiningProvider.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffCodeMiningProvider.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+import org.eclipse.compare.internal.CompareMessages;
 import org.eclipse.compare.unifieddiff.UnifiedDiffMode;
 import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiff;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -49,6 +50,7 @@ import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.SourceViewer;
 import org.eclipse.jface.text.source.inlined.LineFooterAnnotation;
 import org.eclipse.jface.text.source.inlined.LineHeaderAnnotation;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
@@ -156,6 +158,9 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 				}
 			}
 			if (existingMinings.size() > 0) {
+				// the expander minings are recreated instead of reused so that they
+				// reflect the current expansion state of the folds
+				createFoldRegionCodeMinings(viewer, existingMinings);
 				return CompletableFuture.completedFuture(existingMinings);
 			}
 		}
@@ -164,9 +169,13 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 		// take an immutable snapshot so the async iteration cannot observe
 		// concurrent modifications when accept/hide actions mutate the live list
 		List<UnifiedDiff> diffsSnapshot = List.copyOf(diffs);
+		// created on the calling thread because it reads the projection annotation model
+		List<ICodeMining> foldMinings = new ArrayList<>();
+		createFoldRegionCodeMinings(viewer, foldMinings);
 		return CompletableFuture.supplyAsync(() -> {
 			List<ICodeMining> minings = new ArrayList<>();
 			createLineHeaderCodeMinings(diffsSnapshot, minings, viewer, tabWidth);
+			minings.addAll(foldMinings);
 			return minings;
 		});
 	}
@@ -271,6 +280,53 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 					error(e);
 				}
 			}
+		}
+	}
+
+	/**
+	 * Creates one clickable expander mining per collapsed unchanged-region fold,
+	 * shown as e.g. "Expand 42 unchanged lines" above the fold's caption line.
+	 */
+	private void createFoldRegionCodeMinings(ITextViewer viewer, List<ICodeMining> minings) {
+		IDocument doc = viewer.getDocument();
+		if (doc == null) {
+			return;
+		}
+		Map<Annotation, Position> folds = UnifiedDiffManager.getCollapsedFoldRegions(viewer);
+		for (Map.Entry<Annotation, Position> fold : folds.entrySet()) {
+			Position position = fold.getValue();
+			try {
+				int firstLine = doc.getLineOfOffset(position.getOffset());
+				int lastLine = position.getLength() > 0
+						? doc.getLineOfOffset(position.getOffset() + position.getLength() - 1)
+						: firstLine;
+				// the first line of the region stays visible as the fold's caption
+				int hiddenLines = lastLine - firstLine;
+				if (hiddenLines <= 0) {
+					continue;
+				}
+				minings.add(new FoldedRegionCodeMining(new Position(position.getOffset(), 1), this, viewer,
+						fold.getKey(), hiddenLines));
+			} catch (BadLocationException e) {
+				error(e);
+			}
+		}
+	}
+
+	static class FoldedRegionCodeMining extends LineHeaderCodeMining {
+
+		private final String expandLabel;
+
+		public FoldedRegionCodeMining(Position position, ICodeMiningProvider provider, ITextViewer viewer,
+				Annotation foldAnnotation, int hiddenLines) throws BadLocationException {
+			super(position, provider, e -> UnifiedDiffManager.expandFoldRegion(viewer, foldAnnotation));
+			this.expandLabel = hiddenLines == 1 ? CompareMessages.UnifiedDiff_expandUnchangedLine
+					: NLS.bind(CompareMessages.UnifiedDiff_expandUnchangedLines, Integer.valueOf(hiddenLines));
+		}
+
+		@Override
+		public String getLabel() {
+			return this.expandLabel;
 		}
 	}
 

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffCodeMiningProvider.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffCodeMiningProvider.java
@@ -25,12 +25,14 @@ import static org.eclipse.compare.unifieddiff.internal.UnifiedDiffText.replaceTa
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+import org.eclipse.compare.internal.CompareMessages;
 import org.eclipse.compare.unifieddiff.UnifiedDiffMode;
 import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiff;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -55,6 +57,8 @@ import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.SourceViewer;
 import org.eclipse.jface.text.source.inlined.LineFooterAnnotation;
 import org.eclipse.jface.text.source.inlined.LineHeaderAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
@@ -82,6 +86,8 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 
 	private Color deletionBackgroundColor;
 	private Color detailedDiffColor;
+	private Color foldSeparatorColor;
+	private Color foldButtonColor;
 	private boolean lastIsOverlay;
 
 	@Override
@@ -95,6 +101,14 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 				detailedDiffColor.dispose();
 			}
 			detailedDiffColor = null;
+			if (foldSeparatorColor != null && !foldSeparatorColor.isDisposed()) {
+				foldSeparatorColor.dispose();
+			}
+			foldSeparatorColor = null;
+			if (foldButtonColor != null && !foldButtonColor.isDisposed()) {
+				foldButtonColor.dispose();
+			}
+			foldButtonColor = null;
 		} finally {
 			super.dispose();
 		}
@@ -126,43 +140,25 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 			if (this.deletionBackgroundColor != null && !this.deletionBackgroundColor.isDisposed()) {
 				this.deletionBackgroundColor.dispose();
 			}
+			if (this.foldSeparatorColor != null && !this.foldSeparatorColor.isDisposed()) {
+				this.foldSeparatorColor.dispose();
+			}
+			if (this.foldButtonColor != null && !this.foldButtonColor.isDisposed()) {
+				this.foldButtonColor.dispose();
+			}
 			this.detailedDiffColor = new Color(interpolate(deletionColor, background, 0.9));
 			this.deletionBackgroundColor = new Color(interpolate(deletionColor, background, 0.8));
+			this.foldSeparatorColor = new Color(separatorBackground(background));
+			this.foldButtonColor = new Color(buttonBackground(background));
 			lastIsOverlay = isOverlay;
 		}
-		if (viewer instanceof ISourceViewer sv && UnifiedDiffManager.get(viewer) != null) {
-			List<ICodeMining> existingMinings = new ArrayList<>();
-			IAnnotationModel model = sv.getAnnotationModel();
-			Iterator<Annotation> it = model.getAnnotationIterator();
-			while (it.hasNext()) {
-				Annotation next = it.next();
-				if (next instanceof LineHeaderAnnotation n) {
-					try {
-						List<ICodeMining> m = n.getMinings();
-						if (m != null && m.size() == 1 && m.get(0) instanceof UnifiedDiffLineHeaderCodeMining idlhcm) {
-							Position p = n.getPosition();
-							IDocument doc = sv.getDocument();
-							int line = doc.getLineOfOffset(p.offset);
-							idlhcm.getPosition().offset = doc.getLineOffset(line); // we need to recalculate the line
-																					// offset for the scenario where
-																					// source is modified at the
-																					// beginning of the line
-							existingMinings.add(idlhcm);
-						}
-					} catch (BadLocationException e) {
-						error(e);
-					}
-				} else if (next instanceof LineFooterAnnotation footer) {
-					List<ICodeMining> m = footer.getMinings();
-					if (m != null && m.size() == 1 && m.get(0) instanceof UnifiedDiffFooterCodeMining idlhcm) {
-						IDocument doc = sv.getDocument();
-						idlhcm.getPosition().offset = doc.getLength();
-						existingMinings.add(idlhcm);
-					}
-				}
-			}
-			if (existingMinings.size() > 0) {
-				return CompletableFuture.completedFuture(existingMinings);
+		if (viewer instanceof ISourceViewer sv) {
+			List<ICodeMining> attached = attachedMiningsOf(sv, diffs);
+			if (attached != null) {
+				// the expander minings are recreated instead of reused so that they
+				// reflect the current expansion state of the folds
+				createFoldRegionCodeMinings(viewer, attached);
+				return CompletableFuture.completedFuture(attached);
 			}
 		}
 
@@ -170,9 +166,13 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 		// take an immutable snapshot so the async iteration cannot observe
 		// concurrent modifications when accept/hide actions mutate the live list
 		List<UnifiedDiff> diffsSnapshot = List.copyOf(diffs);
+		// created on the calling thread because it reads the projection annotation model
+		List<ICodeMining> foldMinings = new ArrayList<>();
+		createFoldRegionCodeMinings(viewer, foldMinings);
 		return CompletableFuture.supplyAsync(() -> {
 			List<ICodeMining> minings = new ArrayList<>();
 			createLineHeaderCodeMinings(diffsSnapshot, minings, viewer, tabWidth);
+			minings.addAll(foldMinings);
 			return minings;
 		});
 	}
@@ -217,6 +217,73 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 		return tabWidth;
 	}
 
+	/** Whether the diff shows content of the other side, which takes a mining. */
+	public static boolean needsCodeMining(UnifiedDiff diff) {
+		return diff.mode.equals(UnifiedDiffMode.REPLACE_MODE) ? !diff.leftStr.isEmpty() : !diff.rightStr.isEmpty();
+	}
+
+	/**
+	 * Returns the attached minings of the diffs, one per diff that takes one, or
+	 * {@code null} when a diff has none and they have to be rebuilt. Minings of
+	 * diffs that are no longer shown are left out, so what an earlier request
+	 * attached never decides what is shown.
+	 */
+	private static List<ICodeMining> attachedMiningsOf(ISourceViewer sv, List<UnifiedDiff> diffs) {
+		IAnnotationModel model = sv.getAnnotationModel();
+		IDocument doc = sv.getDocument();
+		if (model == null || doc == null) {
+			return null;
+		}
+		Map<UnifiedDiff, ICodeMining> attached = new IdentityHashMap<>();
+		Iterator<Annotation> it = model.getAnnotationIterator();
+		while (it.hasNext()) {
+			Annotation next = it.next();
+			UnifiedDiff diff;
+			ICodeMining mining;
+			if (next instanceof LineHeaderAnnotation header) {
+				List<ICodeMining> m = header.getMinings();
+				if (m.size() != 1 || !(m.get(0) instanceof UnifiedDiffLineHeaderCodeMining lineHeaderMining)) {
+					continue;
+				}
+				try {
+					// the annotation followed the edits of the document, the mining has not
+					int line = doc.getLineOfOffset(header.getPosition().offset);
+					lineHeaderMining.getPosition().offset = doc.getLineOffset(line);
+				} catch (BadLocationException e) {
+					error(e);
+					continue;
+				}
+				diff = lineHeaderMining.getUnifiedDiff();
+				mining = lineHeaderMining;
+			} else if (next instanceof LineFooterAnnotation footer) {
+				List<ICodeMining> m = footer.getMinings();
+				if (m.size() != 1 || !(m.get(0) instanceof UnifiedDiffFooterCodeMining footerMining)) {
+					continue;
+				}
+				footerMining.getPosition().offset = doc.getLength();
+				diff = footerMining.getUnifiedDiff();
+				mining = footerMining;
+			} else {
+				continue;
+			}
+			if (attached.put(diff, mining) != null) {
+				return null;
+			}
+		}
+		List<ICodeMining> minings = new ArrayList<>();
+		for (UnifiedDiff diff : diffs) {
+			if (!needsCodeMining(diff)) {
+				continue;
+			}
+			ICodeMining mining = attached.get(diff);
+			if (mining == null) {
+				return null;
+			}
+			minings.add(mining);
+		}
+		return minings;
+	}
+
 	private void createLineHeaderCodeMinings(List<UnifiedDiff> diffs, List<ICodeMining> minings, ITextViewer tv,
 			int tabWidth) {
 		if (diffs == null) {
@@ -224,34 +291,17 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 		}
 		IDocument doc = tv.getDocument();
 		for (UnifiedDiff diff : diffs) {
-			if (diff.mode.equals(UnifiedDiffMode.REPLACE_MODE)) {
-				if (diff.leftStr.isEmpty()) {
-					continue;
-				}
-				try {
-					minings.add(createMining(doc, diff, diff.leftStart, tabWidth, tv));
-				} catch (BadLocationException e) {
-					error(e);
-				}
-			} else if (diff.mode.equals(UnifiedDiffMode.OVERLAY_MODE)
-					|| diff.mode.equals(UnifiedDiffMode.OVERLAY_READ_ONLY_MODE)) {
-				if (diff.rightStr.isEmpty()) {
-					continue;
-				}
-				try {
-					minings.add(createMining(doc, diff, diff.leftStart + diff.leftLength, tabWidth, tv));
-				} catch (BadLocationException e) {
-					error(e);
-				}
-			} else if (diff.mode.equals(UnifiedDiffMode.REVERT_MODE)) {
-				if (diff.rightStr.isEmpty()) {
-					continue;
-				}
-				try {
-					minings.add(createMining(doc, diff, diff.leftStart, tabWidth, tv));
-				} catch (BadLocationException e) {
-					error(e);
-				}
+			if (!needsCodeMining(diff)) {
+				continue;
+			}
+			// an overlay sits on the line after the range it stands for
+			boolean overlay = diff.mode.equals(UnifiedDiffMode.OVERLAY_MODE)
+					|| diff.mode.equals(UnifiedDiffMode.OVERLAY_READ_ONLY_MODE);
+			int offset = overlay ? diff.leftStart + diff.leftLength : diff.leftStart;
+			try {
+				minings.add(createMining(doc, diff, offset, tabWidth, tv));
+			} catch (BadLocationException e) {
+				error(e);
 			}
 		}
 	}
@@ -277,6 +327,164 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 
 	private static boolean startsLine(IDocument doc, int offset) throws BadLocationException {
 		return doc.getLineOffset(doc.getLineOfOffset(offset)) == offset;
+	}
+
+	/**
+	 * Creates one clickable mining per unchanged-region fold, which shows the
+	 * region while it is collapsed and hides it again while it is expanded.
+	 */
+	private void createFoldRegionCodeMinings(ITextViewer viewer, List<ICodeMining> minings) {
+		IDocument doc = viewer.getDocument();
+		if (doc == null) {
+			return;
+		}
+		Map<Annotation, Position> folds = UnifiedDiffManager.getFoldRegions(viewer);
+		for (Map.Entry<Annotation, Position> fold : folds.entrySet()) {
+			Position position = fold.getValue();
+			boolean collapsed = fold.getKey() instanceof ProjectionAnnotation p && p.isCollapsed();
+			try {
+				int firstLine = doc.getLineOfOffset(position.getOffset());
+				int lastLine = position.getLength() > 0
+						? doc.getLineOfOffset(position.getOffset() + position.getLength() - 1)
+						: firstLine;
+				// the first line of the region stays visible as the fold's caption
+				int foldableLines = lastLine - firstLine;
+				if (foldableLines <= 0) {
+					continue;
+				}
+				// The band keeps the same line whether the region is collapsed or not, so
+				// that toggling it does not move it away from the pointer that just
+				// clicked it. A line header mining is drawn above its line, so the line
+				// after the region puts the band in the gap while the region is collapsed
+				// and directly below the block once it is expanded. The only other line
+				// visible in both states is the caption, and a band above the caption
+				// would claim the gap is before a line that is still there.
+				int anchorLine = lastLine + 1;
+				if (anchorLine >= doc.getNumberOfLines()) {
+					continue;
+				}
+				int anchor = doc.getLineOffset(anchorLine);
+				if (anchor >= doc.getLength()) {
+					// the empty last line of a document ending in a line delimiter has
+					// neither a character nor a delimiter to repaint, so an annotation
+					// there never reaches the drawing strategy
+					continue;
+				}
+				Position anchorPosition = new Position(anchor, 1);
+				minings.add(new FoldedRegionCodeMining(anchorPosition, this, viewer, fold.getKey(), foldableLines,
+						collapsed, this.foldSeparatorColor, this.foldButtonColor));
+			} catch (BadLocationException e) {
+				error(e);
+			}
+		}
+	}
+
+	/**
+	 * A band that stands out from the surrounding text, so the collapsed region
+	 * reads as a break between two hunks rather than as another line of the file.
+	 */
+	private static RGB separatorBackground(RGB background) {
+		return interpolate(contrasting(background), background, 0.88);
+	}
+
+	/** The expander reads as a control, so it is tinted more strongly than its band. */
+	private static RGB buttonBackground(RGB background) {
+		return interpolate(contrasting(background), background, 0.72);
+	}
+
+	private static RGB contrasting(RGB background) {
+		boolean dark = background != null && (background.red + background.green + background.blue) / 3 < 128;
+		return dark ? new RGB(255, 255, 255) : new RGB(0, 0, 0);
+	}
+
+	public static class FoldedRegionCodeMining extends LineHeaderCodeMining {
+
+		/** Width of the expander button, in multiples of the band height. */
+		private static final int BUTTON_WIDTHS = 2;
+
+		private final String bandLabel;
+		private final boolean collapsed;
+		private final Color separatorColor;
+		private final Color buttonColor;
+
+		public FoldedRegionCodeMining(Position position, ICodeMiningProvider provider, ITextViewer viewer,
+				Annotation foldAnnotation, int foldableLines, boolean collapsed, Color separatorColor,
+				Color buttonColor) throws BadLocationException {
+			super(position, provider, e -> {
+				if (collapsed) {
+					UnifiedDiffManager.expandFoldRegion(viewer, foldAnnotation);
+				} else {
+					UnifiedDiffManager.collapseFoldRegion(viewer, foldAnnotation);
+				}
+			});
+			this.bandLabel = label(foldableLines, collapsed);
+			this.collapsed = collapsed;
+			this.separatorColor = separatorColor;
+			this.buttonColor = buttonColor;
+		}
+
+		private static String label(int foldableLines, boolean collapsed) {
+			if (collapsed) {
+				return foldableLines == 1 ? CompareMessages.UnifiedDiff_showUnchangedLine
+						: NLS.bind(CompareMessages.UnifiedDiff_showUnchangedLines, Integer.valueOf(foldableLines));
+			}
+			return foldableLines == 1 ? CompareMessages.UnifiedDiff_hideUnchangedLine
+					: NLS.bind(CompareMessages.UnifiedDiff_hideUnchangedLines, Integer.valueOf(foldableLines));
+		}
+
+		/** Whether clicking this band shows the region rather than hiding it again. */
+		public boolean isExpander() {
+			return this.collapsed;
+		}
+
+		@Override
+		public String getLabel() {
+			return this.bandLabel;
+		}
+
+		@Override
+		public Point draw(GC gc, StyledText textWidget, Color color, int x, int y) {
+			if (this.separatorColor == null || this.separatorColor.isDisposed() || this.buttonColor == null
+					|| this.buttonColor.isDisposed()) {
+				return super.draw(gc, textWidget, color, x, y);
+			}
+			gc.setFont(textWidget.getFont());
+			String label = getLabel();
+			Point extent = gc.stringExtent(label);
+			int height = extent.y;
+			int width = textWidget.getBounds().width;
+			int buttonWidth = BUTTON_WIDTHS * height;
+			gc.setBackground(this.separatorColor);
+			gc.fillRectangle(0, y, width, height);
+			gc.setBackground(this.buttonColor);
+			gc.fillRectangle(0, y, buttonWidth, height);
+			gc.setForeground(textWidget.getForeground());
+			drawChevrons(gc, buttonWidth / 2, y + height / 2, height, this.collapsed);
+			gc.drawString(label, x + buttonWidth, y, true);
+			return new Point(buttonWidth + extent.x, height);
+		}
+
+		/**
+		 * Two chevrons, pointing apart to show the region and together to hide it
+		 * again. Drawn rather than loaded as an icon so that they follow the
+		 * editor's foreground colour in every theme.
+		 */
+		private static void drawChevrons(GC gc, int centerX, int centerY, int height, boolean apart) {
+			int arm = Math.max(2, height / 4);
+			// Tips that point at each other need more room between them than tips that
+			// point away, otherwise the two chevrons meet in the middle and read as a
+			// cross rather than as a pair.
+			int gap = apart ? Math.max(1, height / 6) : Math.max(3, height / 5);
+			int tip = apart ? gap + arm : gap;
+			int base = apart ? gap : gap + arm;
+			int previousWidth = gc.getLineWidth();
+			gc.setLineWidth(Math.max(1, height / 8));
+			gc.drawPolyline(new int[] { centerX - arm, centerY - base, centerX, centerY - tip, centerX + arm,
+					centerY - base });
+			gc.drawPolyline(new int[] { centerX - arm, centerY + base, centerX, centerY + tip, centerX + arm,
+					centerY + base });
+			gc.setLineWidth(previousWidth);
+		}
 	}
 
 	static class UnifiedDiffFooterCodeMining extends DocumentFooterCodeMining {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffManager.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffManager.java
@@ -67,6 +67,8 @@ import org.eclipse.jface.text.source.IAnnotationModelListener;
 import org.eclipse.jface.text.source.IAnnotationModelListenerExtension;
 import org.eclipse.jface.text.source.ISourceViewerExtension5;
 import org.eclipse.jface.text.source.inlined.AbstractInlinedAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
@@ -102,6 +104,7 @@ public class UnifiedDiffManager {
 	private static final String CURRENT_SELECTED_UNIFIED_DIFF_ANNO_KEY = "CURRENT_SELECTED_UNIFIED_DIFF_ANNO_KEY"; //$NON-NLS-1$
 	private static final String UNDO_LISTENER_KEY = "UNIFIED_DIFF_UNDO_LISTENER_KEY"; //$NON-NLS-1$
 	private static final String UNIFIED_DIFF_ANNOTATION_MODEL_LISTENER_KEY = "UNIFIED_DIFF_ANNOTATION_MODEL_LISTENER_KEY"; //$NON-NLS-1$
+	private static final String UNIFIED_DIFF_FOLD_LISTENER_KEY = "UNIFIED_DIFF_FOLD_LISTENER_KEY"; //$NON-NLS-1$
 	private static final String ADDITION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.addition"; //$NON-NLS-1$
 	private static final String DELETION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.deletion"; //$NON-NLS-1$
 	private static final String DETAILED_ADDITION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.detailedAddition"; //$NON-NLS-1$
@@ -120,10 +123,12 @@ public class UnifiedDiffManager {
 
 	public static IStatus open(ITextEditor editor, String source, UnifiedDiffMode mode, List<Action> additionalActions,
 			TokenComparatorFactory tokenComparatorFactory,
-			IgnoreWhitespaceContributorFactory ignoreWhitespaceContributorFactory, boolean ignoreWhiteSpace) {
+			IgnoreWhitespaceContributorFactory ignoreWhitespaceContributorFactory, boolean ignoreWhiteSpace,
+			int foldContextLines) {
 		ITextViewer viewer = editor.getAdapter(ITextViewer.class);
 		if (viewer instanceof ProjectionViewer pv) {
 			pv.doOperation(ProjectionViewer.EXPAND_ALL);
+			removeFoldAnnotations(pv);
 		}
 		IAnnotationModel model = editor.getDocumentProvider().getAnnotationModel(editor.getEditorInput());
 		if (model == null) {
@@ -310,6 +315,10 @@ public class UnifiedDiffManager {
 		addUndoListener(viewer, leftDocument, model);
 		addAnnoModelChangeListener(viewer, model);
 
+		if (foldContextLines >= 0 && viewer instanceof ProjectionViewer pv) {
+			foldUnchangedRegions(pv, leftDocument, unifiedDiffs, mode, foldContextLines);
+		}
+
 		if (unifiedDiffs.size() > 0) {
 			runAfterRepaintFinished(viewer.getTextWidget(), () -> {
 				Annotation firstAnno = getFirstAnnotationForUnifiedDiff(model, unifiedDiffs.get(0));
@@ -317,6 +326,194 @@ public class UnifiedDiffManager {
 			});
 		}
 		return Status.OK_STATUS;
+	}
+
+	/**
+	 * Marker for the projection annotations added to collapse unchanged regions so
+	 * they can be told apart from the editor's own (e.g. structural) folds.
+	 */
+	private static final class UnifiedDiffFoldAnnotation extends ProjectionAnnotation {
+		UnifiedDiffFoldAnnotation() {
+			super(true); // initially collapsed
+		}
+	}
+
+	/**
+	 * Collapses the unchanged regions between the displayed diffs, keeping
+	 * {@code contextLines} visible next to each change. Reuses the editor's
+	 * projection (folding) model, so this is a no-op when folding is disabled for
+	 * the editor.
+	 */
+	private static void foldUnchangedRegions(ProjectionViewer viewer, IDocument document,
+			List<UnifiedDiff> unifiedDiffs, UnifiedDiffMode mode, int contextLines) {
+		ProjectionAnnotationModel projectionModel = viewer.getProjectionAnnotationModel();
+		if (projectionModel == null || unifiedDiffs.isEmpty()) {
+			return;
+		}
+		// At least one context line so that the expander code mining and the code
+		// minings anchored to the first line after a change never share a line.
+		int context = Math.max(1, contextLines);
+		int lineCount = document.getNumberOfLines();
+		Map<ProjectionAnnotation, Position> foldsToAdd = new HashMap<>();
+		try {
+			// The unchanged regions are the gaps in the document before, between and
+			// after the displayed diffs.
+			int gapStart = 0; // first line of the current unchanged gap
+			for (int i = 0; i <= unifiedDiffs.size(); i++) {
+				boolean atStart = i == 0;
+				boolean atEnd = i == unifiedDiffs.size();
+				int gapEnd = atEnd ? lineCount : document.getLineOfOffset(unifiedDiffs.get(i).leftStart); // exclusive
+				// Keep context lines next to an adjacent change; none is reserved at the
+				// file start or end because there is no neighboring change there. The first
+				// folded line stays visible as the fold's caption.
+				int foldFirst = gapStart + (atStart ? 0 : context);
+				int foldEnd = gapEnd - (atEnd ? 0 : context); // exclusive
+				if (foldEnd - foldFirst >= 2) { // at least one line is hidden below the caption
+					int offset = document.getLineOffset(foldFirst);
+					int end = foldEnd < lineCount ? document.getLineOffset(foldEnd) : document.getLength();
+					if (end > offset) {
+						foldsToAdd.put(new UnifiedDiffFoldAnnotation(), new Position(offset, end - offset));
+					}
+				}
+				if (!atEnd) {
+					UnifiedDiff diff = unifiedDiffs.get(i);
+					// The displayed range has the same length as the diff annotation: in
+					// replace mode the document already contains the right content.
+					int length = UnifiedDiffMode.REPLACE_MODE.equals(mode) ? diff.rightLength : diff.leftLength;
+					int lastOffset = length > 0 ? diff.leftStart + length - 1 : diff.leftStart;
+					gapStart = Math.max(gapStart,
+							document.getLineOfOffset(Math.min(lastOffset, document.getLength())) + 1);
+				}
+			}
+		} catch (BadLocationException e) {
+			error(e);
+			return;
+		}
+		if (!foldsToAdd.isEmpty()) {
+			addFoldChangeListener(viewer);
+			projectionModel.replaceAnnotations(null, foldsToAdd);
+		}
+	}
+
+	/**
+	 * Removes the unchanged-region folds previously added by
+	 * {@link #foldUnchangedRegions}, leaving the editor's own folds untouched.
+	 */
+	private static void removeFoldAnnotations(ProjectionViewer viewer) {
+		ProjectionAnnotationModel projectionModel = viewer.getProjectionAnnotationModel();
+		if (projectionModel == null) {
+			return;
+		}
+		StyledText tw = viewer.getTextWidget();
+		if (tw != null && !tw.isDisposed()) {
+			var listener = (IAnnotationModelListener) tw.getData(UNIFIED_DIFF_FOLD_LISTENER_KEY);
+			if (listener != null) {
+				tw.setData(UNIFIED_DIFF_FOLD_LISTENER_KEY, null);
+				projectionModel.removeAnnotationModelListener(listener);
+			}
+		}
+		List<Annotation> toRemove = new ArrayList<>();
+		for (Iterator<Annotation> it = projectionModel.getAnnotationIterator(); it.hasNext();) {
+			Annotation annotation = it.next();
+			if (annotation instanceof UnifiedDiffFoldAnnotation) {
+				toRemove.add(annotation);
+			}
+		}
+		if (!toRemove.isEmpty()) {
+			projectionModel.replaceAnnotations(toRemove.toArray(new Annotation[0]), null);
+		}
+	}
+
+	/**
+	 * Returns the currently collapsed unchanged-region folds of the given viewer
+	 * with their positions.
+	 */
+	static Map<Annotation, Position> getCollapsedFoldRegions(ITextViewer viewer) {
+		Map<Annotation, Position> result = new HashMap<>();
+		if (viewer instanceof ProjectionViewer pv) {
+			ProjectionAnnotationModel projectionModel = pv.getProjectionAnnotationModel();
+			if (projectionModel != null) {
+				for (Iterator<Annotation> it = projectionModel.getAnnotationIterator(); it.hasNext();) {
+					Annotation annotation = it.next();
+					if (annotation instanceof UnifiedDiffFoldAnnotation fold && fold.isCollapsed()) {
+						Position position = projectionModel.getPosition(annotation);
+						if (position != null && !position.isDeleted()) {
+							result.put(annotation, position);
+						}
+					}
+				}
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Expands the given unchanged-region fold in the given viewer.
+	 */
+	static void expandFoldRegion(ITextViewer viewer, Annotation annotation) {
+		if (viewer instanceof ProjectionViewer pv) {
+			ProjectionAnnotationModel projectionModel = pv.getProjectionAnnotationModel();
+			if (projectionModel != null) {
+				projectionModel.expand(annotation);
+			}
+		}
+	}
+
+	/**
+	 * Refreshes the code minings when unchanged-region folds are expanded or
+	 * collapsed, so their inline expanders appear and disappear accordingly.
+	 */
+	private static void addFoldChangeListener(ProjectionViewer viewer) {
+		StyledText tw = viewer.getTextWidget();
+		ProjectionAnnotationModel projectionModel = viewer.getProjectionAnnotationModel();
+		if (tw == null || tw.isDisposed() || projectionModel == null
+				|| tw.getData(UNIFIED_DIFF_FOLD_LISTENER_KEY) != null) {
+			return;
+		}
+		IAnnotationModelListener listener = new FoldChangeListener(viewer);
+		tw.setData(UNIFIED_DIFF_FOLD_LISTENER_KEY, listener);
+		projectionModel.addAnnotationModelListener(listener);
+	}
+
+	private static final class FoldChangeListener
+			implements IAnnotationModelListener, IAnnotationModelListenerExtension {
+
+		private final ProjectionViewer viewer;
+
+		FoldChangeListener(ProjectionViewer viewer) {
+			this.viewer = viewer;
+		}
+
+		@Override
+		public void modelChanged(AnnotationModelEvent event) {
+			if (!concernsFolds(event.getAddedAnnotations()) && !concernsFolds(event.getRemovedAnnotations())
+					&& !concernsFolds(event.getChangedAnnotations())) {
+				return;
+			}
+			StyledText tw = viewer.getTextWidget();
+			if (tw == null || tw.isDisposed()) {
+				return;
+			}
+			if (viewer instanceof ISourceViewerExtension5 ext) {
+				ext.updateCodeMinings();
+			}
+		}
+
+		private static boolean concernsFolds(Annotation[] annotations) {
+			if (annotations != null) {
+				for (Annotation annotation : annotations) {
+					if (annotation instanceof UnifiedDiffFoldAnnotation) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
+		@Override
+		public void modelChanged(IAnnotationModel model) {
+			// handled by the AnnotationModelEvent variant
+		}
 	}
 
 	static boolean isViewerInPart(IWorkbenchPart part, ITextViewer viewer) {
@@ -1173,6 +1370,9 @@ public class UnifiedDiffManager {
 		if (tw == null || tw.isDisposed()) {
 			// SWT removes listeners automatically when the widget is disposed
 			return;
+		}
+		if (tv instanceof ProjectionViewer pv) {
+			removeFoldAnnotations(pv);
 		}
 		tw.getTypedListeners(SWT.MouseMove, UnifiedDiffMouseMoveListener.class)
 				.forEach(tw::removeMouseMoveListener);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffManager.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffManager.java
@@ -15,11 +15,15 @@ package org.eclipse.compare.unifieddiff.internal;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
@@ -59,6 +63,7 @@ import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension4;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.codemining.ICodeMining;
@@ -72,6 +77,8 @@ import org.eclipse.jface.text.source.IAnnotationModelListenerExtension;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.ISourceViewerExtension5;
 import org.eclipse.jface.text.source.inlined.AbstractInlinedAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
@@ -107,6 +114,8 @@ public class UnifiedDiffManager {
 	private static final String CURRENT_SELECTED_UNIFIED_DIFF_ANNO_KEY = "CURRENT_SELECTED_UNIFIED_DIFF_ANNO_KEY"; //$NON-NLS-1$
 	private static final String UNDO_LISTENER_KEY = "UNIFIED_DIFF_UNDO_LISTENER_KEY"; //$NON-NLS-1$
 	private static final String UNIFIED_DIFF_ANNOTATION_MODEL_LISTENER_KEY = "UNIFIED_DIFF_ANNOTATION_MODEL_LISTENER_KEY"; //$NON-NLS-1$
+	private static final String UNIFIED_DIFF_FOLD_LISTENER_KEY = "UNIFIED_DIFF_FOLD_LISTENER_KEY"; //$NON-NLS-1$
+	private static final String UNIFIED_DIFF_SHADOWED_FOLDS_KEY = "UNIFIED_DIFF_SHADOWED_FOLDS_KEY"; //$NON-NLS-1$
 	private static final String ADDITION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.addition"; //$NON-NLS-1$
 	private static final String DELETION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.deletion"; //$NON-NLS-1$
 	private static final String DETAILED_ADDITION_ANNO_TYPE = "org.eclipse.compare.unifieddiff.internal.detailedAddition"; //$NON-NLS-1$
@@ -162,16 +171,33 @@ public class UnifiedDiffManager {
 
 	public static IStatus open(ITextEditor editor, String source, UnifiedDiffMode mode, List<Action> additionalActions,
 			TokenComparatorFactory tokenComparatorFactory,
-			IgnoreWhitespaceContributorFactory ignoreWhitespaceContributorFactory, boolean ignoreWhiteSpace) {
+			IgnoreWhitespaceContributorFactory ignoreWhitespaceContributorFactory, boolean ignoreWhiteSpace,
+			int foldContextLines) {
 		ITextViewer viewer = editor.getAdapter(ITextViewer.class);
-		if (viewer instanceof ProjectionViewer pv) {
-			pv.doOperation(ProjectionViewer.EXPAND_ALL);
-		}
 		IDocument leftDocument = editor.getDocumentProvider().getDocument(editor.getEditorInput());
 		IAnnotationModel editorModel = annotationModelOf(editor);
 		IAnnotationModel model = editorModel != null ? editorModel : installAnnotationModel(viewer, leftDocument);
 		if (model == null) {
 			return Status.CANCEL_STATUS;
+		}
+		IFile file = editor.getEditorInput().getAdapter(IFile.class);
+		return open(viewer, leftDocument, model, file, source, mode, additionalActions, tokenComparatorFactory,
+				ignoreWhitespaceContributorFactory, ignoreWhiteSpace, foldContextLines);
+	}
+
+	/**
+	 * Shows the diff between the document of the viewer and the source in the
+	 * viewer, replacing a diff shown there before. The file is the one the document
+	 * belongs to, if any; it is checked for being editable before it is modified.
+	 */
+	public static IStatus open(ITextViewer viewer, IDocument leftDocument, IAnnotationModel model, IFile file,
+			String source, UnifiedDiffMode mode, List<Action> additionalActions,
+			TokenComparatorFactory tokenComparatorFactory,
+			IgnoreWhitespaceContributorFactory ignoreWhitespaceContributorFactory, boolean ignoreWhiteSpace,
+			int foldContextLines) {
+		if (viewer instanceof ProjectionViewer pv) {
+			pv.doOperation(ProjectionViewer.EXPAND_ALL);
+			removeFoldAnnotations(pv);
 		}
 		clearAll(viewer, model);
 
@@ -188,7 +214,6 @@ public class UnifiedDiffManager {
 		// mode the document is not modified, so skip the check to avoid prompting
 		// the user to make the file writable for a purely read-only diff
 		if (!UnifiedDiffMode.OVERLAY_READ_ONLY_MODE.equals(mode)) {
-			IFile file = editor.getEditorInput().getAdapter(IFile.class);
 			if (file != null && !validateEdit(file)) {
 				return Status.CANCEL_STATUS;
 			}
@@ -262,6 +287,10 @@ public class UnifiedDiffManager {
 		addUndoListener(viewer, leftDocument, model);
 		addAnnoModelChangeListener(viewer, model);
 
+		if (foldContextLines >= 0 && viewer instanceof ProjectionViewer pv) {
+			foldUnchangedRegions(pv, leftDocument, unifiedDiffs, mode, foldContextLines);
+		}
+
 		if (unifiedDiffs.size() > 0) {
 			runAfterRepaintFinished(viewer.getTextWidget(), () -> {
 				Annotation firstAnno = getFirstAnnotationForUnifiedDiff(model, unifiedDiffs.get(0));
@@ -269,6 +298,381 @@ public class UnifiedDiffManager {
 			});
 		}
 		return Status.OK_STATUS;
+	}
+
+	/**
+	 * Marker for the projection annotations added to collapse unchanged regions so
+	 * they can be told apart from the editor's own (e.g. structural) folds.
+	 */
+	private static final class UnifiedDiffFoldAnnotation extends ProjectionAnnotation {
+		UnifiedDiffFoldAnnotation() {
+			super(true); // initially collapsed
+		}
+	}
+
+	/**
+	 * Collapses the unchanged regions between the displayed diffs, keeping
+	 * {@code contextLines} visible next to each change. Reuses the editor's
+	 * projection (folding) model, so this is a no-op when folding is disabled for
+	 * the editor. Folds of the editor that a collapsed region would swallow are
+	 * taken out of the model until that region is expanded again.
+	 */
+	public static void foldUnchangedRegions(ProjectionViewer viewer, IDocument document,
+			List<UnifiedDiff> unifiedDiffs, UnifiedDiffMode mode, int contextLines) {
+		ProjectionAnnotationModel projectionModel = viewer.getProjectionAnnotationModel();
+		if (projectionModel == null) {
+			return;
+		}
+		Map<ProjectionAnnotation, Position> foldsToAdd = new HashMap<>();
+		for (Position region : unchangedFoldRegions(document, unifiedDiffs, mode, contextLines)) {
+			foldsToAdd.put(new UnifiedDiffFoldAnnotation(), region);
+		}
+		if (!foldsToAdd.isEmpty()) {
+			addFoldChangeListener(viewer);
+			projectionModel.replaceAnnotations(null, foldsToAdd);
+			syncShadowedEditorFolds(viewer);
+		}
+	}
+
+	/**
+	 * Returns the regions to collapse: the unchanged gaps before, between and after
+	 * the given diffs, each shortened by {@code contextLines} towards a neighboring
+	 * change. A gap that would not hide a line below its caption is left out.
+	 */
+	public static List<Position> unchangedFoldRegions(IDocument document, List<UnifiedDiff> unifiedDiffs, UnifiedDiffMode mode,
+			int contextLines) {
+		if (unifiedDiffs.isEmpty()) {
+			return List.of();
+		}
+		// At least one context line so that the expander code mining and the code
+		// minings anchored to the first line after a change never share a line.
+		int context = Math.max(1, contextLines);
+		int lineCount = document.getNumberOfLines();
+		// The gaps are walked front to back, so the diffs have to be in document order
+		// rather than in whatever order the caller collected them.
+		List<UnifiedDiff> diffs = new ArrayList<>(unifiedDiffs);
+		diffs.sort(Comparator.comparingInt(diff -> diff.leftStart));
+		List<Position> regions = new ArrayList<>();
+		try {
+			// The unchanged regions are the gaps in the document before, between and
+			// after the displayed diffs.
+			int gapStart = 0; // first line of the current unchanged gap
+			for (int i = 0; i <= diffs.size(); i++) {
+				boolean atStart = i == 0;
+				boolean atEnd = i == diffs.size();
+				int gapEnd = atEnd ? lineCount : document.getLineOfOffset(diffs.get(i).leftStart); // exclusive
+				// Keep context lines next to an adjacent change; none is reserved at the
+				// file start or end because there is no neighboring change there. The first
+				// folded line stays visible as the fold's caption.
+				int foldFirst = gapStart + (atStart ? 0 : context);
+				// A region reaching the end of the document stops above the line that
+				// carries its expander.
+				int foldEnd = atEnd ? expanderLine(document) : gapEnd - context; // exclusive
+				if (foldEnd - foldFirst >= 2) { // at least one line is hidden below the caption
+					int offset = document.getLineOffset(foldFirst);
+					int end = foldEnd < lineCount ? document.getLineOffset(foldEnd) : document.getLength();
+					// A file ending in a line delimiter has an empty last line that the
+					// region would reach without covering it, which leaves a fold that the
+					// expander code mining does not count and therefore cannot expand.
+					if (end > offset && document.getLineOfOffset(end - 1) > foldFirst) {
+						regions.add(new Position(offset, end - offset));
+					}
+				}
+				if (!atEnd) {
+					UnifiedDiff diff = diffs.get(i);
+					// The displayed range has the same length as the diff annotation: in
+					// replace mode the document already contains the right content.
+					int length = UnifiedDiffMode.REPLACE_MODE.equals(mode) ? diff.rightLength : diff.leftLength;
+					int lastOffset = length > 0 ? diff.leftStart + length - 1 : diff.leftStart;
+					gapStart = Math.max(gapStart,
+							document.getLineOfOffset(Math.min(lastOffset, document.getLength())) + 1);
+				}
+			}
+		} catch (BadLocationException e) {
+			error(e);
+			return List.of();
+		}
+		return regions;
+	}
+
+	/**
+	 * The line that carries the expander of a fold reaching the end of the
+	 * document. A line header code mining is drawn above its own line, so that line
+	 * has to stay outside the fold. A document ending in a line delimiter has an
+	 * empty last line, and an annotation there is never redrawn because it has
+	 * neither a character nor a delimiter to repaint, so the line before it is used.
+	 */
+	private static int expanderLine(IDocument document) throws BadLocationException {
+		int last = document.getNumberOfLines() - 1;
+		if (last > 0 && document.getLineLength(last) == 0) {
+			return last - 1;
+		}
+		return last;
+	}
+
+	/**
+	 * Removes the unchanged-region folds previously added by
+	 * {@link #foldUnchangedRegions}, leaving the editor's own folds untouched.
+	 */
+	private static void removeFoldAnnotations(ProjectionViewer viewer) {
+		ProjectionAnnotationModel projectionModel = viewer.getProjectionAnnotationModel();
+		if (projectionModel == null) {
+			return;
+		}
+		StyledText tw = viewer.getTextWidget();
+		if (tw != null && !tw.isDisposed()) {
+			var listener = (IAnnotationModelListener) tw.getData(UNIFIED_DIFF_FOLD_LISTENER_KEY);
+			if (listener != null) {
+				tw.setData(UNIFIED_DIFF_FOLD_LISTENER_KEY, null);
+				projectionModel.removeAnnotationModelListener(listener);
+			}
+		}
+		List<Annotation> toRemove = new ArrayList<>();
+		for (Iterator<Annotation> it = projectionModel.getAnnotationIterator(); it.hasNext();) {
+			Annotation annotation = it.next();
+			if (annotation instanceof UnifiedDiffFoldAnnotation) {
+				toRemove.add(annotation);
+			}
+		}
+		if (!toRemove.isEmpty()) {
+			projectionModel.replaceAnnotations(toRemove.toArray(new Annotation[0]), null);
+		}
+		// nothing is collapsed any more, so every fold of the editor is usable again
+		syncShadowedEditorFolds(viewer);
+		if (!toRemove.isEmpty() && viewer instanceof ISourceViewerExtension5 ext) {
+			// the listener is already gone, so nothing else drops the expander minings
+			// of the regions just removed
+			ext.updateCodeMinings();
+		}
+	}
+
+	/**
+	 * Whether a fold starting at the given position is swallowed by one of the
+	 * collapsed regions. The folding ruler paints such a fold on the first line of
+	 * it that is still visible but toggles it by its start line, so its indicator
+	 * either sits on a foreign line where clicking it does nothing, or shares the
+	 * caption line of the collapsed region and competes with it.
+	 */
+	public static boolean isShadowedByCollapsedRegion(Position fold, Collection<Position> collapsedRegions) {
+		for (Position region : collapsedRegions) {
+			if (region.getOffset() <= fold.getOffset() && fold.getOffset() < region.getOffset() + region.getLength()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Takes the editor's own folds that a collapsed unchanged region swallowed out
+	 * of the projection model and puts back those that became usable again, so that
+	 * the folding ruler only ever offers indicators that do something.
+	 */
+	private static void syncShadowedEditorFolds(ProjectionViewer viewer) {
+		ProjectionAnnotationModel projectionModel = viewer.getProjectionAnnotationModel();
+		StyledText tw = viewer.getTextWidget();
+		if (projectionModel == null || tw == null || tw.isDisposed()) {
+			return;
+		}
+		IDocument document = viewer.getDocument();
+		if (document == null) {
+			return;
+		}
+		long stamp = modificationStamp(document);
+		Collection<Position> collapsed = getCollapsedFoldRegions(viewer).values();
+		Map<Annotation, ShadowedFold> shadowed = getShadowedEditorFolds(tw);
+		Set<Integer> presentStarts = new HashSet<>();
+		List<Annotation> toHide = new ArrayList<>();
+		for (Iterator<Annotation> it = projectionModel.getAnnotationIterator(); it.hasNext();) {
+			Annotation annotation = it.next();
+			if (annotation instanceof UnifiedDiffFoldAnnotation || !(annotation instanceof ProjectionAnnotation fold)) {
+				continue;
+			}
+			Position position = projectionModel.getPosition(annotation);
+			if (position == null || position.isDeleted()) {
+				continue;
+			}
+			presentStarts.add(Integer.valueOf(position.getOffset()));
+			// a collapsed fold hides itself entirely, so it has no indicator that could
+			// end up on a foreign line and taking it out would show its content again
+			if (!fold.isCollapsed() && isShadowedByCollapsedRegion(position, collapsed)) {
+				toHide.add(annotation);
+				shadowed.put(annotation, new ShadowedFold(position, stamp));
+			}
+		}
+		Map<Annotation, Position> toRestore = new HashMap<>();
+		for (Iterator<Map.Entry<Annotation, ShadowedFold>> it = shadowed.entrySet().iterator(); it.hasNext();) {
+			Map.Entry<Annotation, ShadowedFold> entry = it.next();
+			ShadowedFold fold = entry.getValue();
+			if (isShadowedByCollapsedRegion(fold.position(), collapsed)) {
+				continue;
+			}
+			it.remove();
+			// out of the model the position no longer follows the document, so it only
+			// still describes the fold as long as nothing was edited; a fold the editor
+			// recreated in the meantime already occupies the indicator line
+			if (fold.modificationStamp() != stamp || fold.position().isDeleted()
+					|| presentStarts.contains(Integer.valueOf(fold.position().getOffset()))) {
+				continue;
+			}
+			toRestore.put(entry.getKey(), fold.position());
+		}
+		if (!toHide.isEmpty() || !toRestore.isEmpty()) {
+			projectionModel.replaceAnnotations(toHide.toArray(new Annotation[0]), toRestore);
+		}
+	}
+
+	/** A fold of the editor taken out of the projection model, as it was then. */
+	private record ShadowedFold(Position position, long modificationStamp) {
+	}
+
+	private static long modificationStamp(IDocument document) {
+		return document instanceof IDocumentExtension4 ext ? ext.getModificationStamp()
+				: IDocumentExtension4.UNKNOWN_MODIFICATION_STAMP;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<Annotation, ShadowedFold> getShadowedEditorFolds(StyledText tw) {
+		Map<Annotation, ShadowedFold> folds = (Map<Annotation, ShadowedFold>) tw
+				.getData(UNIFIED_DIFF_SHADOWED_FOLDS_KEY);
+		if (folds == null) {
+			folds = new HashMap<>();
+			tw.setData(UNIFIED_DIFF_SHADOWED_FOLDS_KEY, folds);
+		}
+		return folds;
+	}
+
+	/**
+	 * Returns the currently collapsed unchanged-region folds of the given viewer
+	 * with their positions.
+	 */
+	static Map<Annotation, Position> getCollapsedFoldRegions(ITextViewer viewer) {
+		return foldRegions(viewer, true);
+	}
+
+	/**
+	 * Returns the unchanged-region folds of the given viewer with their positions,
+	 * whether they are collapsed or expanded. An expanded one is still a region the
+	 * user can hide again.
+	 */
+	static Map<Annotation, Position> getFoldRegions(ITextViewer viewer) {
+		return foldRegions(viewer, false);
+	}
+
+	private static Map<Annotation, Position> foldRegions(ITextViewer viewer, boolean collapsedOnly) {
+		Map<Annotation, Position> result = new HashMap<>();
+		if (viewer instanceof ProjectionViewer pv) {
+			ProjectionAnnotationModel projectionModel = pv.getProjectionAnnotationModel();
+			if (projectionModel != null) {
+				for (Iterator<Annotation> it = projectionModel.getAnnotationIterator(); it.hasNext();) {
+					Annotation annotation = it.next();
+					if (annotation instanceof UnifiedDiffFoldAnnotation fold
+							&& (fold.isCollapsed() || !collapsedOnly)) {
+						Position position = projectionModel.getPosition(annotation);
+						if (position != null && !position.isDeleted()) {
+							result.put(annotation, position);
+						}
+					}
+				}
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Expands the given unchanged-region fold in the given viewer.
+	 */
+	static void expandFoldRegion(ITextViewer viewer, Annotation annotation) {
+		if (viewer instanceof ProjectionViewer pv) {
+			ProjectionAnnotationModel projectionModel = pv.getProjectionAnnotationModel();
+			if (projectionModel != null) {
+				projectionModel.expand(annotation);
+			}
+		}
+	}
+
+	/**
+	 * Collapses the given unchanged-region fold in the given viewer again.
+	 */
+	static void collapseFoldRegion(ITextViewer viewer, Annotation annotation) {
+		if (viewer instanceof ProjectionViewer pv) {
+			ProjectionAnnotationModel projectionModel = pv.getProjectionAnnotationModel();
+			if (projectionModel != null) {
+				projectionModel.collapse(annotation);
+			}
+		}
+	}
+
+	/**
+	 * Refreshes the code minings when unchanged-region folds are expanded or
+	 * collapsed, so their inline expanders appear and disappear accordingly.
+	 */
+	private static void addFoldChangeListener(ProjectionViewer viewer) {
+		StyledText tw = viewer.getTextWidget();
+		ProjectionAnnotationModel projectionModel = viewer.getProjectionAnnotationModel();
+		if (tw == null || tw.isDisposed() || projectionModel == null
+				|| tw.getData(UNIFIED_DIFF_FOLD_LISTENER_KEY) != null) {
+			return;
+		}
+		IAnnotationModelListener listener = new FoldChangeListener(viewer);
+		tw.setData(UNIFIED_DIFF_FOLD_LISTENER_KEY, listener);
+		projectionModel.addAnnotationModelListener(listener);
+	}
+
+	private static final class FoldChangeListener
+			implements IAnnotationModelListener, IAnnotationModelListenerExtension {
+
+		private final ProjectionViewer viewer;
+
+		FoldChangeListener(ProjectionViewer viewer) {
+			this.viewer = viewer;
+		}
+
+		@Override
+		public void modelChanged(AnnotationModelEvent event) {
+			// folds the editor contributes later, such as after a reconcile, have to be
+			// checked against the collapsed regions as well
+			if (!event.isWorldChange() && !concernsFolds(event, ProjectionAnnotation.class)) {
+				return;
+			}
+			StyledText tw = viewer.getTextWidget();
+			if (tw == null || tw.isDisposed()) {
+				return;
+			}
+			boolean ownFolds = event.isWorldChange() || concernsFolds(event, UnifiedDiffFoldAnnotation.class);
+			// the model is in the middle of a change and may even notify from its own
+			// thread, so do the rest once that change is through and on the UI thread
+			tw.getDisplay().asyncExec(() -> {
+				if (tw.isDisposed()) {
+					return;
+				}
+				syncShadowedEditorFolds(viewer);
+				if (ownFolds && viewer instanceof ISourceViewerExtension5 ext) {
+					ext.updateCodeMinings();
+				}
+			});
+		}
+
+		private static boolean concernsFolds(AnnotationModelEvent event, Class<? extends Annotation> foldType) {
+			return concernsFolds(event.getAddedAnnotations(), foldType)
+					|| concernsFolds(event.getRemovedAnnotations(), foldType)
+					|| concernsFolds(event.getChangedAnnotations(), foldType);
+		}
+
+		private static boolean concernsFolds(Annotation[] annotations, Class<? extends Annotation> foldType) {
+			if (annotations != null) {
+				for (Annotation annotation : annotations) {
+					if (foldType.isInstance(annotation)) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
+		@Override
+		public void modelChanged(IAnnotationModel model) {
+			// handled by the AnnotationModelEvent variant
+		}
 	}
 
 	static boolean isViewerInPart(IWorkbenchPart part, ITextViewer viewer) {
@@ -638,9 +1042,13 @@ public class UnifiedDiffManager {
 		StyledText tw = tv.getTextWidget();
 		removeAnnotationModelListener(model, tw);
 		for (UnifiedDiff diff : diffs1) {
-			List<Annotation> annos = getAllAnnotationsForUnifiedDiff(model, diff);
-			for (var lanno : annos) {
-				model.removeAnnotation(lanno);
+			for (Annotation annotation : getAllAnnotationsForUnifiedDiff(model, diff)) {
+				// the code mining annotation belongs to the framework, which drops it
+				// once the provider stops returning its mining; taken out here, the
+				// framework keeps it as attached and never puts a mining back there
+				if (!(annotation instanceof AbstractInlinedAnnotation)) {
+					model.removeAnnotation(annotation);
+				}
 			}
 		}
 		diffs1.clear();
@@ -1254,6 +1662,9 @@ public class UnifiedDiffManager {
 		if (tw == null || tw.isDisposed()) {
 			// SWT removes listeners automatically when the widget is disposed
 			return;
+		}
+		if (tv instanceof ProjectionViewer pv) {
+			removeFoldAnnotations(pv);
 		}
 		tw.getTypedListeners(SWT.MouseMove, UnifiedDiffMouseMoveListener.class)
 				.forEach(tw::removeMouseMoveListener);

--- a/team/bundles/org.eclipse.compare/plugin.properties
+++ b/team/bundles/org.eclipse.compare/plugin.properties
@@ -126,7 +126,9 @@ ComparePreferencePage.structureCompare.label= &Open structure compare automatica
 ComparePreferencePage.structureOutline.label= Show structure compare in Outline &view when possible
 ComparePreferencePage.ignoreWhitespace.label= Ignore &white space
 ComparePreferencePage.saveBeforePatching.label= A&utomatically save editors with unsaved changes before browsing patches
+ComparePreferencePage.unifiedDiffGroup.label=Unified Diff
 ComparePreferencePage.unifiedDiff.label=EXPERIMENTAL: Use Unified Diff instead of 2-way compare when possible
+ComparePreferencePage.unifiedDiffFoldUnchanged.label=&Fold unchanged regions, keeping a few lines of context around each change
 
 ComparePreferencePage.regex.description=Enter regular expressions used to identify added or removed lines in a patch\n(e.g. '^\\+\\s*\\S' for an added line with at least one word character).
 ComparePreferencePage.regexAdded.label=Added lines

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/AllTeamUITests.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/core/AllTeamUITests.java
@@ -15,7 +15,10 @@ package org.eclipse.team.tests.core;
 
 import org.eclipse.team.tests.core.mapping.AllTeamMappingTests;
 import org.eclipse.team.tests.ui.SaveableCompareEditorInputTest;
+import org.eclipse.team.tests.ui.UnifiedDiffCodeMiningProviderTest;
+import org.eclipse.team.tests.ui.UnifiedDiffFoldRegionsTest;
 import org.eclipse.team.tests.ui.UnifiedDiffManagerTest;
+import org.eclipse.team.tests.ui.UnifiedDiffShadowedFoldsTest;
 import org.eclipse.team.tests.ui.UnifiedDiffTextTest;
 import org.eclipse.team.tests.ui.synchronize.AllTeamSynchronizeTests;
 import org.junit.platform.suite.api.SelectClasses;
@@ -26,7 +29,10 @@ import org.junit.platform.suite.api.Suite;
 		AllTeamMappingTests.class, //
 		AllTeamSynchronizeTests.class, //
 		SaveableCompareEditorInputTest.class, //
+		UnifiedDiffCodeMiningProviderTest.class, //
+		UnifiedDiffFoldRegionsTest.class, //
 		UnifiedDiffManagerTest.class, //
+		UnifiedDiffShadowedFoldsTest.class, //
 		UnifiedDiffTextTest.class, //
 })
 public class AllTeamUITests {

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/UnifiedDiffCodeMiningProviderTest.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/UnifiedDiffCodeMiningProviderTest.java
@@ -1,0 +1,574 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eclipse contributors - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.team.tests.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+import org.eclipse.compare.unifieddiff.UnifiedDiffMode;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffCodeMiningProvider;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffCodeMiningProvider.FoldedRegionCodeMining;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffCodeMiningProvider.UnifiedDiffLineHeaderCodeMining;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiff;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.codemining.ICodeMining;
+import org.eclipse.jface.text.codemining.ICodeMiningProvider;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.AnnotationModel;
+import org.eclipse.jface.text.source.AnnotationPainter;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.jface.text.source.inlined.AbstractInlinedAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
+import org.eclipse.jface.text.source.projection.ProjectionViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.text.undo.DocumentUndoManagerRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the code minings of the unified diff describe the diffs and the
+ * collapsed regions shown at the time they are computed, whatever the code
+ * mining framework still has attached to the viewer from an earlier request.
+ */
+@SuppressWarnings("restriction")
+public class UnifiedDiffCodeMiningProviderTest {
+
+	private static final UnifiedDiffMode MODE = UnifiedDiffMode.OVERLAY_READ_ONLY_MODE;
+	private static final int CONTEXT_LINES = 3;
+	private static final int TIMEOUT_SECONDS = 10;
+
+	private Display display;
+	private Shell shell;
+	private ProjectionViewer viewer;
+	private IDocument document;
+	private IAnnotationModel model;
+	private UnifiedDiffCodeMiningProvider provider;
+	private final List<CompletableFuture<List<? extends ICodeMining>>> pendingRequests = new ArrayList<>();
+
+	@BeforeEach
+	public void setUp() {
+		display = Display.getDefault();
+		assertNotNull(Display.getCurrent(), "the test drives the viewer from the UI thread");
+		shell = new Shell(display);
+		document = numberedLines(60);
+		model = new AnnotationModel();
+		viewer = new ProjectionViewer(shell, null, null, false, SWT.V_SCROLL);
+		viewer.setDocument(document, model);
+		viewer.enableProjection();
+		DocumentUndoManagerRegistry.connect(document);
+		provider = new UnifiedDiffCodeMiningProvider();
+	}
+
+	@AfterEach
+	public void tearDown() {
+		DocumentUndoManagerRegistry.disconnect(document);
+		if (shell != null && !shell.isDisposed()) {
+			shell.dispose();
+		}
+		waitForPendingWork();
+	}
+
+	/**
+	 * Opening a diff on a viewer that already shows one clears the shown diffs in
+	 * place and puts the new ones while the minings of the old ones are still
+	 * attached. The framework's requests are asynchronous and each one cancels the
+	 * one before it, so the provider can be asked at any point in between and must
+	 * answer from the current diffs and folds, never from what it finds attached.
+	 */
+	@Test
+	public void testMiningsFollowTheDiffsAndFoldsThroughAReopen() throws Exception {
+		installCodeMinings(provider);
+		assertTrue(open(withChangedLines(10, 45)).isOK());
+		List<UnifiedDiff> first = UnifiedDiffManager.get(viewer);
+		assertEquals(2, first.size(), "one diff per changed line");
+		waitForAttachedMinings(first, allRegions().size());
+		viewer.doOperation(ProjectionViewer.EXPAND_ALL);
+		waitForPendingWork();
+		assertThat(collapsedRegions()).as("everything is expanded again").isEmpty();
+		assertThat(allRegions()).as("the regions are still there, ready to be hidden again").isNotEmpty();
+
+		assertMinings(provide(), first);
+
+		UnifiedDiffManager.foldUnchangedRegions(viewer, document, first, MODE, CONTEXT_LINES);
+		waitForPendingWork();
+		assertThat(collapsedRegions()).as("the unchanged regions are collapsed").hasSize(3);
+		assertMinings(provide(), first);
+
+		// what a reopen does before the framework caught up: the old list is cleared
+		// in place and a new one with the same diffs is put
+		List<UnifiedDiff> second = diffsOnLines(10, 45);
+		first.clear();
+		UnifiedDiffManager.put(viewer, second);
+		assertMinings(provide(), second);
+
+		// a reopen showing fewer diffs than there are minings attached
+		List<UnifiedDiff> third = diffsOnLines(45);
+		second.clear();
+		UnifiedDiffManager.put(viewer, third);
+		assertMinings(provide(), third);
+
+		// the framework caught up, then lost the mining of one diff again
+		viewer.updateCodeMinings();
+		waitForAttachedMinings(third, allRegions().size());
+		List<UnifiedDiff> fourth = diffsOnLines(10, 45);
+		third.clear();
+		UnifiedDiffManager.put(viewer, fourth);
+		viewer.updateCodeMinings();
+		waitForAttachedMinings(fourth, allRegions().size());
+		model.removeAnnotation(attachedMiningAnnotationOf(fourth.get(0)));
+		assertMinings(provide(), fourth);
+	}
+
+	/**
+	 * The expander stands for the lines a region hides, and those lie below the
+	 * region's own first line, which stays visible as the fold's caption. Drawn
+	 * above the caption it would claim the gap is before a line that is still
+	 * there, so it belongs to the first line after the region.
+	 */
+	@Test
+	public void testTheExpanderSitsInTheGapAndNotAboveTheCaption() throws Exception {
+		installCodeMinings(provider);
+		assertTrue(open(withChangedLines(10, 45)).isOK());
+		List<Position> collapsed = collapsedRegions();
+		assertThat(collapsed).as("the unchanged regions are collapsed").isNotEmpty();
+
+		for (ICodeMining mining : provide()) {
+			if (!(mining instanceof FoldedRegionCodeMining expander)) {
+				continue;
+			}
+			assertTrue(expander.isExpander(), "every band of a collapsed region shows it rather than hides it");
+			int anchor = expander.getPosition().getOffset();
+			Position region = regionEndingBefore(collapsed, anchor);
+			assertNotNull(region, "every expander belongs to a collapsed region, but none ends before " + anchor);
+			int captionLine = document.getLineOfOffset(region.getOffset());
+			int anchorLine = document.getLineOfOffset(anchor);
+			assertTrue(anchorLine > captionLine,
+					"the expander must be drawn below the caption line " + captionLine + ", not above it at line "
+							+ anchorLine);
+			assertEquals(document.getLineOfOffset(region.getOffset() + region.getLength() - 1) + 1, anchorLine,
+					"the expander belongs to the first line after the region");
+		}
+	}
+
+	/**
+	 * A region the user expanded can be hidden again: its band stays where it was
+	 * and turns into a collapsing one.
+	 */
+	@Test
+	public void testAnExpandedRegionOffersToHideItselfAgain() throws Exception {
+		installCodeMinings(provider);
+		assertTrue(open(withChangedLines(10, 45)).isOK());
+		assertThat(collapsedRegions()).as("the regions start collapsed").isNotEmpty();
+		int regions = allRegions().size();
+
+		viewer.doOperation(ProjectionViewer.EXPAND_ALL);
+		waitForPendingWork();
+		assertThat(collapsedRegions()).as("nothing is collapsed any more").isEmpty();
+
+		List<FoldedRegionCodeMining> bands = new ArrayList<>();
+		for (ICodeMining mining : provide()) {
+			if (mining instanceof FoldedRegionCodeMining band) {
+				bands.add(band);
+			}
+		}
+		assertEquals(regions, bands.size(), "every expanded region keeps a band to hide it again");
+		for (FoldedRegionCodeMining band : bands) {
+			assertFalse(band.isExpander(), "an expanded region's band hides it rather than showing it");
+			assertThat(band.getLabel()).as("the label offers to hide the lines").contains("Hide");
+			int anchorLine = document.getLineOfOffset(band.getPosition().getOffset());
+			Position region = regionEndingBefore(allRegions().stream().map(FoldRegion::position).toList(),
+					band.getPosition().getOffset());
+			assertNotNull(region, "the band of an expanded region belongs to a region ending before it");
+			assertThat(anchorLine).as("the band sits below the block it would hide")
+					.isGreaterThan(document.getLineOfOffset(region.getOffset()));
+		}
+	}
+
+	/**
+	 * Expanding a region must not move its band. The band is what the user just
+	 * clicked, and the only two lines of a region that are visible in both states
+	 * are its caption and the line after it, so a band that changes ends jumps by
+	 * the whole height of the region; for the region at the start of the file that
+	 * lands on the first line of the document.
+	 */
+	@Test
+	public void testTogglingARegionLeavesItsBandWhereItWas() throws Exception {
+		installCodeMinings(provider);
+		assertTrue(open(withChangedLines(45)).isOK());
+		assertThat(collapsedRegions()).as("the regions start collapsed").isNotEmpty();
+		Map<Integer, Integer> collapsedAnchors = bandAnchorsByRegion();
+		assertThat(collapsedAnchors).as("there is a band to follow").isNotEmpty();
+
+		viewer.doOperation(ProjectionViewer.EXPAND_ALL);
+		waitForPendingWork();
+		assertThat(collapsedRegions()).as("nothing is collapsed any more").isEmpty();
+
+		assertEquals(collapsedAnchors, bandAnchorsByRegion(), "every band stays on the line it was clicked on");
+	}
+
+	/**
+	 * The line each region's band currently sits on, keyed by the region's own first
+	 * line. A band can only be on one of the two lines of its region that are
+	 * visible while it is collapsed, so both are accepted here and it is the
+	 * comparison across a toggle that decides whether the band moved.
+	 */
+	private Map<Integer, Integer> bandAnchorsByRegion() throws Exception {
+		Map<Integer, Integer> anchors = new LinkedHashMap<>();
+		for (ICodeMining mining : provide()) {
+			if (!(mining instanceof FoldedRegionCodeMining band)) {
+				continue;
+			}
+			int anchorLine = document.getLineOfOffset(band.getPosition().getOffset());
+			Integer captionLine = null;
+			for (FoldRegion region : allRegions()) {
+				Position position = region.position();
+				int first = document.getLineOfOffset(position.getOffset());
+				int last = document.getLineOfOffset(position.getOffset() + position.getLength() - 1);
+				if (anchorLine == first || anchorLine == last + 1) {
+					captionLine = Integer.valueOf(first);
+				}
+			}
+			assertNotNull(captionLine, "the band on line " + anchorLine + " belongs to no region");
+			anchors.put(captionLine, Integer.valueOf(anchorLine));
+		}
+		return anchors;
+	}
+
+	/** Hiding a region again puts it back the way the first open had it. */
+	@Test
+	public void testHidingAnExpandedRegionCollapsesItAgain() throws Exception {
+		installCodeMinings(provider);
+		assertTrue(open(withChangedLines(10, 45)).isOK());
+		int collapsedAtFirst = collapsedRegions().size();
+		assertThat(collapsedAtFirst).isPositive();
+
+		viewer.doOperation(ProjectionViewer.EXPAND_ALL);
+		waitForPendingWork();
+		assertThat(collapsedRegions()).isEmpty();
+
+		for (ICodeMining mining : provide()) {
+			if (mining instanceof FoldedRegionCodeMining band) {
+				band.getAction().accept(null);
+			}
+		}
+		waitForPendingWork();
+
+		assertEquals(collapsedAtFirst, collapsedRegions().size(), "every region is collapsed again");
+	}
+
+	/**
+	 * A document ending in a line delimiter has an empty last line. It has neither
+	 * a character nor a line delimiter to repaint, so an annotation there never
+	 * reaches the drawing strategy and its band stays invisible. The region running
+	 * to the end of the document therefore has to stop above the last line that
+	 * carries content.
+	 */
+	@Test
+	public void testTheBandOfTheLastRegionSitsOnALineThatCanBePainted() throws Exception {
+		assertEquals(0, document.getLineLength(document.getNumberOfLines() - 1),
+				"the document under test ends in a line delimiter");
+		installCodeMinings(provider);
+		assertTrue(open(withChangedLines(10)).isOK());
+		assertThat(collapsedRegions()).as("the unchanged regions are collapsed").isNotEmpty();
+
+		List<FoldedRegionCodeMining> bands = new ArrayList<>();
+		for (ICodeMining mining : provide()) {
+			if (mining instanceof FoldedRegionCodeMining band) {
+				bands.add(band);
+			}
+		}
+		assertEquals(allRegions().size(), bands.size(), "every region keeps its band");
+		for (FoldedRegionCodeMining band : bands) {
+			int anchor = band.getPosition().getOffset();
+			assertTrue(anchor < document.getLength(),
+					"a band anchored at the end of the document is never painted, but one sits at " + anchor);
+			assertThat(document.getLineLength(document.getLineOfOffset(anchor)))
+					.as("the band's line has something to repaint").isPositive();
+		}
+	}
+
+	/** The collapsed region whose last line is the one before the given offset. */
+	private Position regionEndingBefore(List<Position> collapsed, int anchor) throws BadLocationException {
+		for (Position region : collapsed) {
+			int lastLine = document.getLineOfOffset(region.getOffset() + region.getLength() - 1);
+			if (document.getLineOffset(lastLine + 1) == anchor) {
+				return region;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * The case seen in the IDE: an editor with another code mining provider that
+	 * answers asynchronously, such as the Java editor. Each request the reopen
+	 * issues cancels the one before it, so the request that would have dropped the
+	 * old minings never renders, and the framework keeps believing they are
+	 * attached. The rebuilt minings must still all reach the editor.
+	 */
+	@Test
+	public void testReopeningNextToAnAsynchronousProviderKeepsEveryMining() throws Exception {
+		installCodeMinings(provider, new PendingProvider());
+		String changed = withChangedLines(10, 45);
+
+		assertTrue(open(changed).isOK());
+		answerPendingRequests();
+		List<UnifiedDiff> diffs = UnifiedDiffManager.get(viewer);
+		assertEquals(2, diffs.size(), "one diff per changed line");
+		assertThat(collapsedRegions()).as("the unchanged regions are collapsed").hasSize(3);
+		waitForAttachedMinings(diffs, allRegions().size());
+
+		assertTrue(open(changed).isOK());
+		answerPendingRequests();
+		diffs = UnifiedDiffManager.get(viewer);
+		assertEquals(2, diffs.size(), "one diff per changed line");
+		assertThat(collapsedRegions()).as("the unchanged regions are collapsed again").hasSize(3);
+		waitForAttachedMinings(diffs, allRegions().size());
+	}
+
+	// ------------------------------------------------------------------ helpers
+
+	/** A provider that answers only when the test lets it, like a slow editor. */
+	private final class PendingProvider implements ICodeMiningProvider {
+
+		@Override
+		public CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(ITextViewer textViewer,
+				IProgressMonitor monitor) {
+			CompletableFuture<List<? extends ICodeMining>> request = new CompletableFuture<>();
+			pendingRequests.add(request);
+			return request;
+		}
+
+		@Override
+		public void dispose() {
+			// nothing to release
+		}
+	}
+
+	private void installCodeMinings(ICodeMiningProvider... providers) {
+		viewer.setCodeMiningProviders(providers);
+		AnnotationPainter painter = new AnnotationPainter(viewer, null);
+		viewer.setCodeMiningAnnotationPainter(painter);
+		viewer.addPainter(painter);
+	}
+
+	private IStatus open(String source) {
+		return UnifiedDiffManager.open(viewer, document, model, null, source, MODE, null, null, null, true,
+				CONTEXT_LINES);
+	}
+
+	/**
+	 * Lets the other provider answer every request made so far, once the fold
+	 * listener had its turn and cancelled the requests it supersedes.
+	 */
+	private void answerPendingRequests() {
+		waitForPendingWork();
+		List<CompletableFuture<List<? extends ICodeMining>>> requests = new ArrayList<>(pendingRequests);
+		pendingRequests.clear();
+		for (CompletableFuture<List<? extends ICodeMining>> request : requests) {
+			request.complete(List.of());
+		}
+		waitForPendingWork();
+	}
+
+	private List<ICodeMining> provide() throws Exception {
+		return new ArrayList<>(
+				provider.provideCodeMinings(viewer, new NullProgressMonitor()).get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+	}
+
+	/**
+	 * One overlay mining per diff, showing that very diff, and one expander per
+	 * collapsed region, anchored to the first line after it.
+	 */
+	private void assertMinings(List<ICodeMining> minings, List<UnifiedDiff> diffs) {
+		List<UnifiedDiff> shown = new ArrayList<>();
+		List<Integer> expanders = new ArrayList<>();
+		for (ICodeMining mining : minings) {
+			if (mining instanceof UnifiedDiffLineHeaderCodeMining overlay) {
+				shown.add(overlay.getUnifiedDiff());
+			} else if (mining instanceof FoldedRegionCodeMining expander) {
+				expanders.add(Integer.valueOf(expander.getPosition().getOffset()));
+			} else {
+				fail("unexpected mining " + mining);
+			}
+		}
+		assertThat(shown).as("one overlay mining per shown diff").containsExactlyInAnyOrderElementsOf(diffs);
+		assertThat(expanders).as("one band per region, wherever its state puts it")
+				.containsExactlyInAnyOrderElementsOf(allRegions().stream().map(this::expectedAnchorOf).toList());
+	}
+
+	/**
+	 * Where the band of a region belongs, in either state. A collapsed region keeps
+	 * its own first line visible as the fold's caption, so the line after the region
+	 * is the one line that is visible whether the region is collapsed or not, and
+	 * anchoring there keeps the band still while the user toggles it.
+	 */
+	private Integer expectedAnchorOf(FoldRegion region) {
+		try {
+			int lastLine = document
+					.getLineOfOffset(region.position().getOffset() + region.position().getLength() - 1);
+			return Integer.valueOf(document.getLineOffset(lastLine + 1));
+		} catch (BadLocationException e) {
+			return fail("the region reaches past the document", e);
+		}
+	}
+
+	/** An unchanged-region fold and whether it is currently collapsed. */
+	private record FoldRegion(Position position, boolean collapsed) {
+	}
+
+	/** Every unchanged-region fold of the viewer, collapsed or expanded. */
+	private List<FoldRegion> allRegions() {
+		List<FoldRegion> result = new ArrayList<>();
+		ProjectionAnnotationModel projectionModel = viewer.getProjectionAnnotationModel();
+		for (Iterator<Annotation> it = projectionModel.getAnnotationIterator(); it.hasNext();) {
+			Annotation annotation = it.next();
+			if (annotation instanceof ProjectionAnnotation fold) {
+				result.add(new FoldRegion(projectionModel.getPosition(annotation), fold.isCollapsed()));
+			}
+		}
+		return result;
+	}
+
+	/** Waits until the framework attached exactly the minings of the diffs and regions. */
+	private void waitForAttachedMinings(List<UnifiedDiff> diffs, int regions) {
+		waitUntil(() -> {
+			List<UnifiedDiff> shown = new ArrayList<>();
+			int expanders = 0;
+			for (ICodeMining mining : attachedMinings()) {
+				if (mining instanceof UnifiedDiffLineHeaderCodeMining overlay) {
+					shown.add(overlay.getUnifiedDiff());
+				} else if (mining instanceof FoldedRegionCodeMining) {
+					expanders++;
+				}
+			}
+			return shown.size() == diffs.size() && shown.containsAll(diffs) && diffs.containsAll(shown)
+					&& expanders == regions;
+		}, () -> "the minings of " + diffs.size() + " diffs and " + regions
+				+ " regions are attached, but the model holds " + attachedMinings());
+	}
+
+	private List<ICodeMining> attachedMinings() {
+		List<ICodeMining> result = new ArrayList<>();
+		for (Iterator<Annotation> it = model.getAnnotationIterator(); it.hasNext();) {
+			if (it.next() instanceof AbstractInlinedAnnotation inlined) {
+				result.addAll(inlined.getMinings());
+			}
+		}
+		return result;
+	}
+
+	private Annotation attachedMiningAnnotationOf(UnifiedDiff diff) {
+		for (Iterator<Annotation> it = model.getAnnotationIterator(); it.hasNext();) {
+			Annotation annotation = it.next();
+			if (annotation instanceof AbstractInlinedAnnotation inlined) {
+				for (ICodeMining mining : inlined.getMinings()) {
+					if (mining instanceof UnifiedDiffLineHeaderCodeMining overlay && overlay.getUnifiedDiff() == diff) {
+						return annotation;
+					}
+				}
+			}
+		}
+		return fail("no mining is attached for the diff on line " + diff.leftStart);
+	}
+
+	private List<Position> collapsedRegions() {
+		List<Position> result = new ArrayList<>();
+		ProjectionAnnotationModel projectionModel = viewer.getProjectionAnnotationModel();
+		for (Iterator<Annotation> it = projectionModel.getAnnotationIterator(); it.hasNext();) {
+			Annotation annotation = it.next();
+			if (annotation instanceof ProjectionAnnotation fold && fold.isCollapsed()) {
+				result.add(projectionModel.getPosition(annotation));
+			}
+		}
+		return result;
+	}
+
+	private void waitUntil(BooleanSupplier condition, Supplier<String> what) {
+		long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
+		while (!condition.getAsBoolean()) {
+			if (System.currentTimeMillis() > deadline) {
+				fail("timed out waiting until " + what.get());
+			}
+			if (!display.readAndDispatch()) {
+				try {
+					Thread.sleep(10);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					fail("interrupted");
+				}
+			}
+		}
+	}
+
+	private void waitForPendingWork() {
+		while (display.readAndDispatch()) {
+			// keep going until the queue is empty
+		}
+	}
+
+	/** The document with the given lines changed, as the other side of the diff. */
+	private String withChangedLines(int... lines) {
+		String content = document.get();
+		for (int line : lines) {
+			content = content.replace("line " + line + "\n", "line " + line + " changed\n");
+		}
+		return content;
+	}
+
+	/** The diffs the manager would record for the given changed lines. */
+	private List<UnifiedDiff> diffsOnLines(int... lines) throws BadLocationException {
+		List<UnifiedDiff> diffs = new ArrayList<>();
+		for (int line : lines) {
+			int offset = document.getLineOffset(line);
+			int length = document.getLineLength(line);
+			diffs.add(new UnifiedDiff(document, offset, offset + length, document.get(offset, length), document,
+					offset, offset + length + 8, "line " + line + " changed\n", diffs, MODE));
+		}
+		return diffs;
+	}
+
+	private static IDocument numberedLines(int count) {
+		StringBuilder content = new StringBuilder();
+		for (int i = 0; i < count; i++) {
+			content.append("line ").append(i).append('\n');
+		}
+		return new Document(content.toString());
+	}
+}

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/UnifiedDiffFoldRegionsTest.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/UnifiedDiffFoldRegionsTest.java
@@ -1,0 +1,478 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eclipse contributors - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.team.tests.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.compare.unifieddiff.UnifiedDiffMode;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffCodeMiningProvider;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiff;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.Position;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests which unchanged regions the unified diff collapses. The assertions are
+ * expressed in the lines the user would no longer see: a collapsed region keeps
+ * its first line visible as the caption and hides the rest.
+ */
+@SuppressWarnings("restriction")
+public class UnifiedDiffFoldRegionsTest {
+
+	/**
+	 * The bulk of an unchanged file has to be folded away while the change and the
+	 * requested context around it stay visible.
+	 */
+	@Test
+	public void testContextLinesAroundAChangeStayVisible() throws Exception {
+		IDocument document = numberedLines(40);
+
+		Set<Integer> hidden = hiddenLines(document, 3, changeOnLine(document, 20));
+
+		assertThat(hidden).as("the lines far from the change must be folded away").isNotEmpty();
+		assertVisible(hidden, 20, "the changed line");
+		for (int line = 17; line <= 23; line++) {
+			assertVisible(hidden, line, "context line");
+		}
+		assertTrue(hidden.contains(Integer.valueOf(5)), "line 5 is far from the change and must be hidden");
+		assertTrue(hidden.contains(Integer.valueOf(34)), "line 34 is far from the change and must be hidden");
+	}
+
+	/**
+	 * The context is what the caller asked for, not a fixed amount: a larger context
+	 * has to keep strictly more lines visible.
+	 */
+	@Test
+	public void testALargerContextKeepsMoreLinesVisible() throws Exception {
+		IDocument document = numberedLines(40);
+
+		Set<Integer> withOne = hiddenLines(document, 1, changeOnLine(document, 20));
+		Set<Integer> withFive = hiddenLines(document, 5, changeOnLine(document, 20));
+
+		assertThat(withFive).as("a larger context hides fewer lines").isSubsetOf(withOne);
+		assertThat(withOne).as("a larger context hides fewer lines").isNotEqualTo(withFive);
+		for (int line = 15; line <= 25; line++) {
+			assertVisible(withFive, line, "context line");
+		}
+	}
+
+	/**
+	 * Two changes must each keep their own context, and the gap between them has to
+	 * be folded. A single fold across both would hide a change.
+	 */
+	@Test
+	public void testEveryChangeKeepsItsOwnContext() throws Exception {
+		IDocument document = numberedLines(60);
+
+		Set<Integer> hidden = hiddenLines(document, 2, changeOnLine(document, 10), changeOnLine(document, 45));
+
+		for (int changedLine : new int[] { 10, 45 }) {
+			assertVisible(hidden, changedLine, "changed line");
+			for (int line = changedLine - 2; line <= changedLine + 2; line++) {
+				assertVisible(hidden, line, "context line");
+			}
+		}
+		assertTrue(hidden.contains(Integer.valueOf(28)), "the gap between both changes must be folded");
+		assertTrue(hidden.contains(Integer.valueOf(2)), "the region before the first change must be folded");
+		assertTrue(hidden.contains(Integer.valueOf(55)), "the region after the last change must be folded");
+	}
+
+	/**
+	 * A change on the very first line has no region above it, so no context must be
+	 * reserved there and the fold below it still has to appear.
+	 */
+	@Test
+	public void testChangeOnTheFirstLine() throws Exception {
+		IDocument document = numberedLines(30);
+
+		Set<Integer> hidden = hiddenLines(document, 3, changeOnLine(document, 0));
+
+		assertVisible(hidden, 0, "the changed first line");
+		for (int line = 1; line <= 3; line++) {
+			assertVisible(hidden, line, "context line");
+		}
+		assertTrue(hidden.contains(Integer.valueOf(20)), "the unchanged rest of the file must be folded");
+	}
+
+	/**
+	 * A region that would not hide a single line below its caption costs a fold
+	 * marker and a click without saving anything, so it must not be created.
+	 */
+	@Test
+	public void testNoFoldWhenNothingWouldBeHidden() throws Exception {
+		IDocument document = numberedLines(7);
+
+		List<Position> regions = UnifiedDiffManager.unchangedFoldRegions(document,
+				List.of(changeOnLine(document, 3)), UnifiedDiffMode.OVERLAY_READ_ONLY_MODE, 3);
+
+		assertThat(regions).as("the context covers the whole file, so there is nothing to fold").isEmpty();
+	}
+
+	/** Without a change there is nothing to fold around, so nothing is collapsed. */
+	@Test
+	public void testNoDiffsMeansNoFolds() {
+		List<Position> regions = UnifiedDiffManager.unchangedFoldRegions(numberedLines(40), List.of(),
+				UnifiedDiffMode.OVERLAY_READ_ONLY_MODE, 3);
+
+		assertThat(regions).isEmpty();
+	}
+
+	/**
+	 * At least one context line is kept even when none was asked for, so that the
+	 * expander of a fold and the code mining of the following change cannot end up
+	 * on the same line.
+	 */
+	@Test
+	public void testAtLeastOneContextLineIsKept() throws Exception {
+		IDocument document = numberedLines(40);
+
+		Set<Integer> hidden = hiddenLines(document, 0, changeOnLine(document, 20));
+
+		assertVisible(hidden, 19, "the line above the change");
+		assertVisible(hidden, 21, "the line below the change");
+	}
+
+	/**
+	 * The gaps are walked front to back, so the result must not depend on the order
+	 * in which the caller collected the changes.
+	 */
+	@Test
+	public void testResultDoesNotDependOnTheOrderOfTheDiffs() throws Exception {
+		IDocument document = numberedLines(60);
+		UnifiedDiff first = changeOnLine(document, 10);
+		UnifiedDiff second = changeOnLine(document, 45);
+
+		Set<Integer> inOrder = hiddenLines(document, 2, first, second);
+		Set<Integer> reversed = hiddenLines(document, 2, second, first);
+
+		assertEquals(inOrder, reversed, "reversing the diffs must not change which lines are folded");
+	}
+
+	/** No fold may cover a changed line, whatever the context and the file size. */
+	@Test
+	public void testFoldsNeverHideAChange() throws Exception {
+		IDocument document = numberedLines(200);
+		int[] changedLines = { 0, 7, 8, 50, 120, 121, 199 };
+		List<UnifiedDiff> diffs = new ArrayList<>();
+		for (int line : changedLines) {
+			diffs.add(changeOnLine(document, line));
+		}
+
+		for (int context = 0; context <= 4; context++) {
+			Set<Integer> hidden = hiddenLines(document, context, diffs.toArray(new UnifiedDiff[0]));
+			for (int line : changedLines) {
+				assertVisible(hidden, line, "changed line with context " + context + ":");
+			}
+		}
+	}
+
+	/**
+	 * In replace mode the document already holds the new content, so the folds have
+	 * to give way to the lines the replacement occupies, not to the ones it
+	 * replaced.
+	 */
+	@Test
+	public void testReplaceModeMeasuresTheChangeByItsNewContent() throws Exception {
+		IDocument document = numberedLines(60);
+		// one line of the left side is shown as three lines of the right side
+		UnifiedDiff diff = change(document, 20, 1, 3);
+
+		Set<Integer> inReplaceMode = hiddenLines(document, UnifiedDiffMode.REPLACE_MODE, 2, diff);
+		Set<Integer> inOverlayMode = hiddenLines(document, UnifiedDiffMode.OVERLAY_READ_ONLY_MODE, 2, diff);
+
+		for (int line = 20; line <= 24; line++) {
+			assertVisible(inReplaceMode, line, "the replacement and its context line");
+		}
+		assertTrue(inOverlayMode.contains(Integer.valueOf(24)),
+				"the overlay only occupies the line it is anchored to, so line 24 is foldable there");
+	}
+
+	/**
+	 * An addition at the very end of a file that does not end with a newline sits
+	 * on the last offset of the document. The unchanged lines above it still have
+	 * to be folded.
+	 */
+	@Test
+	public void testAnAdditionAtTheEndOfAFileWithoutATrailingNewline() throws Exception {
+		IDocument document = new Document(numberedLines(40).get().stripTrailing());
+		int end = document.getLength();
+		UnifiedDiff addition = new UnifiedDiff(document, end, end, "", document, end, end + 6, "added\n",
+				new ArrayList<>(), UnifiedDiffMode.OVERLAY_READ_ONLY_MODE);
+
+		Set<Integer> hidden = hiddenLines(document, 3, addition);
+
+		assertTrue(hidden.contains(Integer.valueOf(10)), "the unchanged lines above the addition must be folded");
+	}
+
+	/**
+	 * A file ending with a newline has an empty last line. A change close to it
+	 * must not leave a fold behind that only reaches that line, because the
+	 * expander code mining does not count it and could not expand it again.
+	 */
+	@Test
+	public void testNoFoldForTheEmptyLineOfAFileEndingWithANewline() throws Exception {
+		IDocument document = numberedLines(40);
+
+		Set<Integer> hidden = hiddenLines(document, 1, changeOnLine(document, 37));
+
+		assertVisible(hidden, 39, "the last line with content");
+	}
+
+	/**
+	 * The band of a region is drawn above the first line below it, and the empty
+	 * last line of a file ending with a newline cannot be repainted. A region
+	 * running to the end of the file therefore stops above the last line that
+	 * carries content.
+	 */
+	@Test
+	public void testTheRegionAtTheEndLeavesAPaintableLineForItsBand() throws Exception {
+		IDocument document = numberedLines(40);
+
+		Set<Integer> hidden = hiddenLines(document, 3, changeOnLine(document, 5));
+
+		assertVisible(hidden, 39, "the last line with content");
+	}
+
+	/**
+	 * A deletion is not shown by a code mining but by the annotation on the lines
+	 * it covers, so those lines have to stay visible.
+	 */
+	@Test
+	public void testAPureDeletionStaysVisible() throws Exception {
+		IDocument document = numberedLines(60);
+
+		Set<Integer> hidden = hiddenLines(document, 3, deletionOfLines(document, 30, 2));
+
+		assertVisible(hidden, 30, "the first deleted line");
+		assertVisible(hidden, 31, "the second deleted line");
+	}
+
+	/**
+	 * A pure addition occupies no line of the document. Its code mining is anchored
+	 * to the line it is inserted in front of, which therefore has to stay visible.
+	 */
+	@Test
+	public void testAPureAdditionInTheMiddleOfAFileStaysVisible() throws Exception {
+		IDocument document = numberedLines(60);
+
+		Set<Integer> hidden = hiddenLines(document, 3, additionBeforeLine(document, 30, "added\n"));
+
+		assertVisible(hidden, 30, "the line the addition is anchored to");
+	}
+
+	/**
+	 * A line deleted in one place and added again further down produces a deletion
+	 * and a separate addition. Both ends of the move have to stay visible.
+	 */
+	@Test
+	public void testALineDeletedHereAndAddedLaterIsVisibleAtBothEnds() throws Exception {
+		IDocument document = numberedLines(60);
+		UnifiedDiff deletedHere = deletionOfLines(document, 10, 1);
+		UnifiedDiff addedThere = additionBeforeLine(document, 40, "line 10\n");
+
+		for (int context = 0; context <= 4; context++) {
+			Set<Integer> hidden = hiddenLines(document, context, deletedHere, addedThere);
+			assertVisible(hidden, 10, "the line that was deleted, with context " + context + ":");
+			assertVisible(hidden, 40, "the line the deleted text was added in front of, with context " + context + ":");
+		}
+	}
+
+	/** The same move, with the addition above the deletion in the document. */
+	@Test
+	public void testALineDeletedHereAndAddedEarlierIsVisibleAtBothEnds() throws Exception {
+		IDocument document = numberedLines(60);
+		UnifiedDiff addedThere = additionBeforeLine(document, 10, "line 40\n");
+		UnifiedDiff deletedHere = deletionOfLines(document, 40, 1);
+
+		Set<Integer> hidden = hiddenLines(document, 3, addedThere, deletedHere);
+
+		assertVisible(hidden, 10, "the line the deleted text was added in front of");
+		assertVisible(hidden, 40, "the line that was deleted");
+	}
+
+	/**
+	 * Attached code minings are only reused when every diff that shows content of
+	 * the other side has one. Reusing fewer would drop a diff for good, because
+	 * nothing recomputes it from the diffs afterwards.
+	 */
+	@Test
+	public void testOnlyDiffsShowingTheOtherSideNeedACodeMining() throws Exception {
+		IDocument document = numberedLines(60);
+		UnifiedDiff shownAsOverlay = additionBeforeLine(document, 10, "line 40\n");
+		UnifiedDiff shownOnItsOwnLines = deletionOfLines(document, 40, 1);
+
+		assertTrue(UnifiedDiffCodeMiningProvider.needsCodeMining(shownAsOverlay), "the overlay needs a mining");
+		assertFalse(UnifiedDiffCodeMiningProvider.needsCodeMining(shownOnItsOwnLines),
+				"the deletion is drawn on the lines it covers");
+		assertTrue(UnifiedDiffCodeMiningProvider.needsCodeMining(changeOnLine(document, 50)),
+				"a replacement shows the other side as an overlay too");
+	}
+
+	/**
+	 * A document of a single line has no room for a caption and a hidden line
+	 * below it, so it must not produce a fold at all.
+	 */
+	@Test
+	public void testASingleLineDocumentHasNothingToFold() throws Exception {
+		IDocument document = new Document("line 0");
+
+		List<Position> regions = UnifiedDiffManager.unchangedFoldRegions(document,
+				List.of(changeCoveringTheRest(document, 0)), UnifiedDiffMode.OVERLAY_READ_ONLY_MODE, 3);
+
+		assertThat(regions).as("a one line document cannot hide a line below a caption").isEmpty();
+	}
+
+	/**
+	 * A context larger than the file keeps every line next to the change, so there
+	 * is nothing left to fold and no region may be created.
+	 */
+	@Test
+	public void testAContextLargerThanTheFileFoldsNothing() throws Exception {
+		IDocument document = numberedLines(20);
+
+		List<Position> regions = UnifiedDiffManager.unchangedFoldRegions(document,
+				List.of(changeOnLine(document, 10)), UnifiedDiffMode.OVERLAY_READ_ONLY_MODE, 500);
+
+		assertThat(regions).as("the context covers the whole file").isEmpty();
+	}
+
+	/**
+	 * Diffs that overlap each other must not produce overlapping regions or a
+	 * region that hides one of them. The gaps are walked front to back, so an
+	 * overlapped gap has to be dropped rather than folded backwards.
+	 */
+	@Test
+	public void testOverlappingDiffsProduceNoOverlappingRegions() throws Exception {
+		IDocument document = numberedLines(60);
+		UnifiedDiff first = change(document, 20, 5, 5);
+		UnifiedDiff second = change(document, 22, 5, 5);
+
+		// hiddenLines asserts on its own that no two regions claim the same line
+		Set<Integer> hidden = hiddenLines(document, 2, first, second);
+
+		for (int line = 20; line <= 26; line++) {
+			assertVisible(hidden, line, "line of an overlapping change");
+		}
+		assertTrue(hidden.contains(Integer.valueOf(5)), "the region before the changes must still be folded");
+		assertTrue(hidden.contains(Integer.valueOf(50)), "the region after the changes must still be folded");
+	}
+
+	/**
+	 * A change on the last line of a file that does not end with a newline has no
+	 * region below it, and the unchanged lines above it still have to be folded.
+	 */
+	@Test
+	public void testAChangeOnTheLastLineOfAFileWithoutATrailingNewline() throws Exception {
+		IDocument document = new Document(numberedLines(40).get().stripTrailing());
+		int lastLine = document.getNumberOfLines() - 1;
+
+		Set<Integer> hidden = hiddenLines(document, 3, changeCoveringTheRest(document, lastLine));
+
+		assertVisible(hidden, lastLine, "the changed last line");
+		for (int line = lastLine - 3; line < lastLine; line++) {
+			assertVisible(hidden, line, "context line");
+		}
+		assertTrue(hidden.contains(Integer.valueOf(10)), "the unchanged lines above the change must be folded");
+	}
+
+	// ------------------------------------------------------------------ helpers
+
+	/**
+	 * The lines that the given folds would hide. A collapsed region keeps its first
+	 * line visible as the caption.
+	 */
+	private static Set<Integer> hiddenLines(IDocument document, int contextLines, UnifiedDiff... diffs)
+			throws BadLocationException {
+		return hiddenLines(document, UnifiedDiffMode.OVERLAY_READ_ONLY_MODE, contextLines, diffs);
+	}
+
+	private static Set<Integer> hiddenLines(IDocument document, UnifiedDiffMode mode, int contextLines,
+			UnifiedDiff... diffs) throws BadLocationException {
+		List<Position> regions = UnifiedDiffManager.unchangedFoldRegions(document, Arrays.asList(diffs), mode,
+				contextLines);
+		Set<Integer> hidden = new LinkedHashSet<>();
+		for (Position region : regions) {
+			int firstLine = document.getLineOfOffset(region.getOffset());
+			int lastLine = document.getLineOfOffset(region.getOffset() + region.getLength() - 1);
+			assertTrue(lastLine > firstLine, "a fold that hides nothing must not be created");
+			for (int line = firstLine + 1; line <= lastLine; line++) {
+				assertTrue(hidden.add(Integer.valueOf(line)), "folds must not overlap on line " + line);
+			}
+		}
+		return hidden;
+	}
+
+	private static void assertVisible(Set<Integer> hidden, int line, String what) {
+		assertThat(hidden).as(what + " " + line + " must stay visible").doesNotContain(Integer.valueOf(line));
+	}
+
+	/** A one line change of the given document line, as the manager records it. */
+	private static UnifiedDiff changeOnLine(IDocument document, int line) throws BadLocationException {
+		return change(document, line, 1, 1);
+	}
+
+	/** A deletion: the document holds the lines, the other side does not. */
+	private static UnifiedDiff deletionOfLines(IDocument document, int line, int lines) throws BadLocationException {
+		int offset = document.getLineOffset(line);
+		int end = document.getLineOffset(line + lines);
+		return new UnifiedDiff(document, offset, end, document.get(offset, end - offset), document, offset, offset, "",
+				new ArrayList<>(), UnifiedDiffMode.OVERLAY_READ_ONLY_MODE);
+	}
+
+	/** An addition: the other side holds a line the document does not. */
+	private static UnifiedDiff additionBeforeLine(IDocument document, int line, String added)
+			throws BadLocationException {
+		int offset = document.getLineOffset(line);
+		return new UnifiedDiff(document, offset, offset, "", document, offset, offset + added.length(), added,
+				new ArrayList<>(), UnifiedDiffMode.OVERLAY_READ_ONLY_MODE);
+	}
+
+	/** A change of the given line and everything after it, for a file without a trailing newline. */
+	private static UnifiedDiff changeCoveringTheRest(IDocument document, int line) throws BadLocationException {
+		int offset = document.getLineOffset(line);
+		int end = document.getLength();
+		return new UnifiedDiff(document, offset, end, document.get(offset, end - offset), document, offset, end,
+				"changed", new ArrayList<>(), UnifiedDiffMode.OVERLAY_READ_ONLY_MODE);
+	}
+
+	/** A change of {@code leftLines} shown as {@code rightLines}. */
+	private static UnifiedDiff change(IDocument document, int line, int leftLines, int rightLines)
+			throws BadLocationException {
+		int offset = document.getLineOffset(line);
+		int leftEnd = document.getLineOffset(line + leftLines);
+		int rightEnd = document.getLineOffset(line + rightLines);
+		return new UnifiedDiff(document, offset, leftEnd, document.get(offset, leftEnd - offset), document, offset,
+				rightEnd, "changed\n", new ArrayList<>(), UnifiedDiffMode.OVERLAY_READ_ONLY_MODE);
+	}
+
+	private static IDocument numberedLines(int count) {
+		StringBuilder content = new StringBuilder();
+		for (int i = 0; i < count; i++) {
+			content.append("line ").append(i).append('\n');
+		}
+		return new Document(content.toString());
+	}
+}

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/UnifiedDiffShadowedFoldsTest.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/UnifiedDiffShadowedFoldsTest.java
@@ -1,0 +1,315 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eclipse contributors - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.team.tests.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.compare.unifieddiff.UnifiedDiffMode;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager.UnifiedDiff;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.AnnotationModel;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
+import org.eclipse.jface.text.source.projection.ProjectionViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the unchanged-region folds of the unified diff do not leave the
+ * folding ruler with fold indicators that cannot do anything: the folding ruler
+ * paints a fold whose first line is hidden on the first line of it that is still
+ * visible, but toggles it by its start line, so clicking such an indicator has
+ * no effect.
+ */
+@SuppressWarnings("restriction")
+public class UnifiedDiffShadowedFoldsTest {
+
+	private static final UnifiedDiffMode MODE = UnifiedDiffMode.OVERLAY_READ_ONLY_MODE;
+
+	private Display display;
+	private Shell shell;
+	private ProjectionViewer viewer;
+
+	@BeforeEach
+	public void setUp() {
+		display = Display.getDefault();
+		assertNotNull(display, "the test needs a display");
+		shell = new Shell(display);
+	}
+
+	@AfterEach
+	public void tearDown() {
+		if (shell != null && !shell.isDisposed()) {
+			shell.dispose();
+		}
+	}
+
+	/**
+	 * The case reported on the pull request: a fold of the editor that starts inside
+	 * a collapsed region and reaches out of it. Its indicator would be painted on a
+	 * line the folding ruler does not associate with it, so it has to be taken out
+	 * of the model while the region is collapsed.
+	 */
+	@Test
+	public void testAFoldReachingOutOfACollapsedRegionIsTakenOut() throws Exception {
+		IDocument document = numberedLines(100);
+		ProjectionAnnotationModel projectionModel = openViewer(document);
+		ProjectionAnnotation foldOfTheEditor = addFoldOfTheEditor(projectionModel, document, 10, 70);
+
+		UnifiedDiffManager.foldUnchangedRegions(viewer, document, List.of(changeOnLine(document, 60)), MODE, 3);
+
+		assertFalse(isInModel(projectionModel, foldOfTheEditor),
+				"a fold starting on a hidden line must not keep an indicator that does nothing");
+	}
+
+	/** Expanding the region has to give the fold of the editor back to the user. */
+	@Test
+	public void testAFoldComesBackWhenTheRegionIsExpanded() throws Exception {
+		IDocument document = numberedLines(100);
+		ProjectionAnnotationModel projectionModel = openViewer(document);
+		ProjectionAnnotation foldOfTheEditor = addFoldOfTheEditor(projectionModel, document, 10, 70);
+		UnifiedDiffManager.foldUnchangedRegions(viewer, document, List.of(changeOnLine(document, 60)), MODE, 3);
+		assertFalse(isInModel(projectionModel, foldOfTheEditor), "the fold has to be taken out first");
+
+		viewer.doOperation(ProjectionViewer.EXPAND_ALL);
+		waitForPendingWork();
+
+		assertTrue(isInModel(projectionModel, foldOfTheEditor),
+				"the fold of the editor must be usable again once nothing hides its first line");
+	}
+
+	/**
+	 * A fold whose first line stays visible works as it always did and must be left
+	 * alone.
+	 */
+	@Test
+	public void testAFoldStartingOnAVisibleLineIsKept() throws Exception {
+		IDocument document = numberedLines(100);
+		ProjectionAnnotationModel projectionModel = openViewer(document);
+		// line 58 is one of the context lines kept visible above the change
+		ProjectionAnnotation foldOfTheEditor = addFoldOfTheEditor(projectionModel, document, 58, 90);
+
+		UnifiedDiffManager.foldUnchangedRegions(viewer, document, List.of(changeOnLine(document, 60)), MODE, 3);
+
+		assertTrue(isInModel(projectionModel, foldOfTheEditor), "a fold the user can still click must be kept");
+	}
+
+	/**
+	 * A collapsed fold of the editor hides itself completely, so it has no
+	 * indicator on a foreign line. Taking it out would show its content again.
+	 */
+	@Test
+	public void testACollapsedFoldOfTheEditorIsLeftAlone() throws Exception {
+		IDocument document = numberedLines(100);
+		ProjectionAnnotationModel projectionModel = openViewer(document);
+		ProjectionAnnotation foldOfTheEditor = new ProjectionAnnotation(true);
+		projectionModel.replaceAnnotations(null, Map.of(foldOfTheEditor, lines(document, 10, 70)));
+
+		UnifiedDiffManager.foldUnchangedRegions(viewer, document, List.of(changeOnLine(document, 60)), MODE, 3);
+
+		assertTrue(isInModel(projectionModel, foldOfTheEditor),
+				"taking a collapsed fold out would unfold what the user folded");
+	}
+
+	/**
+	 * The editor contributes its folds asynchronously, so a fold arriving after the
+	 * regions are collapsed has to be taken out as well.
+	 */
+	@Test
+	public void testAFoldContributedAfterTheRegionsAreCollapsedIsTakenOut() throws Exception {
+		IDocument document = numberedLines(100);
+		ProjectionAnnotationModel projectionModel = openViewer(document);
+		UnifiedDiffManager.foldUnchangedRegions(viewer, document, List.of(changeOnLine(document, 60)), MODE, 3);
+		waitForPendingWork();
+
+		ProjectionAnnotation foldOfTheEditor = addFoldOfTheEditor(projectionModel, document, 10, 70);
+		waitForPendingWork();
+
+		assertFalse(isInModel(projectionModel, foldOfTheEditor),
+				"a fold the editor adds later must not keep an indicator that does nothing");
+	}
+
+	/**
+	 * Out of the projection model a position no longer follows the document, so a
+	 * fold taken out before an edit must not be put back at what it described then.
+	 */
+	@Test
+	public void testAFoldIsNotPutBackAfterTheDocumentWasEdited() throws Exception {
+		IDocument document = numberedLines(100);
+		ProjectionAnnotationModel projectionModel = openViewer(document);
+		ProjectionAnnotation foldOfTheEditor = addFoldOfTheEditor(projectionModel, document, 10, 70);
+		UnifiedDiffManager.foldUnchangedRegions(viewer, document, List.of(changeOnLine(document, 60)), MODE, 3);
+
+		document.replace(document.getLineOffset(59), 0, "inserted\n");
+		viewer.doOperation(ProjectionViewer.EXPAND_ALL);
+		waitForPendingWork();
+
+		assertFalse(isInModel(projectionModel, foldOfTheEditor),
+				"a stale fold would put its indicator on the wrong line");
+	}
+
+	/** The collapsed region really has to hide its lines, not just be recorded. */
+	@Test
+	public void testTheCollapsedRegionHidesItsLines() throws Exception {
+		IDocument document = numberedLines(100);
+		openViewer(document);
+
+		UnifiedDiffManager.foldUnchangedRegions(viewer, document, List.of(changeOnLine(document, 60)), MODE, 3);
+
+		String visible = viewer.getTextWidget().getText();
+		assertFalse(visible.contains("line 30"), "a line far from the change must not be shown");
+		assertTrue(visible.contains("line 60"), "the changed line must be shown");
+	}
+
+	/**
+	 * A line deleted in one place and added again further down: the deletion is
+	 * shown on the lines it covers and the addition on the line it is anchored to,
+	 * so the collapsed regions have to leave both of them on screen.
+	 */
+	@Test
+	public void testAMovedLineIsShownAtBothEndsWhenCollapsed() throws Exception {
+		IDocument document = numberedLines(100);
+		openViewer(document);
+		UnifiedDiff deletedHere = deletionOfLine(document, 20);
+		UnifiedDiff addedThere = additionBeforeLine(document, 70, "line 20\n");
+
+		UnifiedDiffManager.foldUnchangedRegions(viewer, document, List.of(deletedHere, addedThere), MODE, 3);
+
+		String visible = viewer.getTextWidget().getText();
+		assertTrue(visible.contains("line 20"), "the deleted line must be shown");
+		assertTrue(visible.contains("line 70"), "the line the addition is anchored to must be shown");
+		assertFalse(visible.contains("line 45"), "a line far from both ends of the move must not be shown");
+	}
+
+	/** A fold starting on the caption line of a region competes with that region. */
+	@Test
+	public void testAFoldOnTheCaptionLineOfARegionIsShadowed() throws Exception {
+		IDocument document = numberedLines(100);
+		List<Position> collapsed = collapsedRegions(document, 3, changeOnLine(document, 60));
+		Position captionLineFold = new Position(collapsed.get(0).getOffset(), document.getLineLength(0));
+
+		assertTrue(UnifiedDiffManager.isShadowedByCollapsedRegion(captionLineFold, collapsed),
+				"two indicators on one line would toggle whichever the ruler happens to find first");
+	}
+
+	/** A fold below the last collapsed region is untouched. */
+	@Test
+	public void testAFoldOutsideEveryRegionIsNotShadowed() throws Exception {
+		IDocument document = numberedLines(100);
+		List<Position> collapsed = collapsedRegions(document, 3, changeOnLine(document, 60));
+
+		assertFalse(UnifiedDiffManager.isShadowedByCollapsedRegion(lines(document, 58, 62), collapsed),
+				"a fold starting in the visible context around a change must be left alone");
+	}
+
+	/** Without a collapsed region nothing is shadowed. */
+	@Test
+	public void testNothingIsShadowedWithoutCollapsedRegions() throws Exception {
+		IDocument document = numberedLines(100);
+
+		assertFalse(UnifiedDiffManager.isShadowedByCollapsedRegion(lines(document, 10, 70), List.of()));
+	}
+
+	// ------------------------------------------------------------------ helpers
+
+	private ProjectionAnnotationModel openViewer(IDocument document) {
+		viewer = new ProjectionViewer(shell, null, null, false, SWT.V_SCROLL);
+		viewer.setDocument(document, new AnnotationModel());
+		viewer.enableProjection();
+		ProjectionAnnotationModel projectionModel = viewer.getProjectionAnnotationModel();
+		assertNotNull(projectionModel, "the viewer must provide a projection model");
+		return projectionModel;
+	}
+
+	private static ProjectionAnnotation addFoldOfTheEditor(ProjectionAnnotationModel projectionModel,
+			IDocument document, int firstLine, int lastLine) throws BadLocationException {
+		ProjectionAnnotation fold = new ProjectionAnnotation();
+		projectionModel.replaceAnnotations(null, Map.of(fold, lines(document, firstLine, lastLine)));
+		return fold;
+	}
+
+	private static List<Position> collapsedRegions(IDocument document, int contextLines, UnifiedDiff... diffs) {
+		return UnifiedDiffManager.unchangedFoldRegions(document, List.of(diffs), MODE, contextLines);
+	}
+
+	private static boolean isInModel(ProjectionAnnotationModel projectionModel, Annotation annotation) {
+		for (Iterator<Annotation> it = projectionModel.getAnnotationIterator(); it.hasNext();) {
+			if (it.next() == annotation) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** Folds are put back from a runnable posted to the display. */
+	private void waitForPendingWork() {
+		while (display.readAndDispatch()) {
+			// keep going until the queue is empty
+		}
+	}
+
+	private static Position lines(IDocument document, int firstLine, int lastLine) throws BadLocationException {
+		int offset = document.getLineOffset(firstLine);
+		int end = document.getLineOffset(lastLine) + document.getLineLength(lastLine);
+		return new Position(offset, end - offset);
+	}
+
+	/** A one line change of the given document line, as the manager records it. */
+	private static UnifiedDiff changeOnLine(IDocument document, int line) throws BadLocationException {
+		int offset = document.getLineOffset(line);
+		int length = document.getLineLength(line);
+		return new UnifiedDiff(document, offset, offset + length, document.get(offset, length), document, offset,
+				offset + length, "changed\n", new ArrayList<>(), MODE);
+	}
+
+	/** A deletion: the document holds the line, the other side does not. */
+	private static UnifiedDiff deletionOfLine(IDocument document, int line) throws BadLocationException {
+		int offset = document.getLineOffset(line);
+		int length = document.getLineLength(line);
+		return new UnifiedDiff(document, offset, offset + length, document.get(offset, length), document, offset,
+				offset, "", new ArrayList<>(), MODE);
+	}
+
+	/** An addition: the other side holds a line the document does not. */
+	private static UnifiedDiff additionBeforeLine(IDocument document, int line, String added)
+			throws BadLocationException {
+		int offset = document.getLineOffset(line);
+		return new UnifiedDiff(document, offset, offset, "", document, offset, offset + added.length(), added,
+				new ArrayList<>(), MODE);
+	}
+
+	private static IDocument numberedLines(int count) {
+		StringBuilder content = new StringBuilder();
+		for (int i = 0; i < count; i++) {
+			content.append("line ").append(i).append('\n');
+		}
+		return new Document(content.toString());
+	}
+}


### PR DESCRIPTION
Folds the unchanged regions of the experimental unified diff overlay, similar to the collapsed context in GitHub's diff view.
The gaps between the displayed changes are collapsed with three context lines kept around each change, which is what makes a large file with few changes reviewable at a glance: `AbstractTextEditor.java` with four changes fits on one screen instead of 8072 lines.
Each collapsed region carries a clickable band that expands it in place and then reads "Hide n unchanged lines", so a region opened by mistake can be put back without going to the folding ruler.
The editor's projection model is reused and the folds are tagged, so tearing the overlay down leaves the editor's own folds alone; a fold the editor contributes inside a collapsed region is taken out while that region is collapsed, because its indicator would otherwise sit on a foreign line and do nothing when clicked.
A "Fold unchanged regions" preference on the Compare page turns the folding off; it is on by default.

Two known limitations.
Reusing projection support means this has no effect in an editor that does not install it, such as the default text editor.
And in a Java editor, revealing a line whose enclosing element is the whole type, a line in the class javadoc for instance, expands every region inside that type, because `JavaEditor.adjustHighlightRange` exposes the element's full source range.

Needs https://github.com/eclipse-platform/eclipse.platform.ui/pull/4361, which is merged.

Part of https://github.com/eclipse-platform/eclipse.platform.ui/issues/3771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019P5XSUkajCGAiyxqAzgymD
