### PR TITLE
Add performance tracing for project refresh duration

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/.options
+++ b/resources/bundles/org.eclipse.core.resources/.options
@@ -15,6 +15,9 @@ org.eclipse.core.resources/perf/snapshot=1000
 # Monitor workspace snapshot and gather time statistics etc.
 org.eclipse.core.resources/perf/save.participants=500
 
+# Monitor workspace refresh and trace if it takes longer than the specified time in milliseconds.
+org.eclipse.core.resources/perf/refresh=500
+
 # Debug build failure cases such as failure to retrieve deltas.
 org.eclipse.core.resources/build/failure=false
 
@@ -76,7 +79,7 @@ org.eclipse.core.resources/save/mastertable=false
 # Report debug of workspace auto-refresh
 org.eclipse.core.resources/refresh=false
 
-# Prints debug information on resource content description 
+# Prints debug information on resource content description
 org.eclipse.core.resources/contenttype=false
 org.eclipse.core.resources/contenttype/cache=false
 

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/ResourceStats.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/ResourceStats.java
@@ -13,8 +13,13 @@
  *******************************************************************************/
 package org.eclipse.core.internal.events;
 
-import org.eclipse.core.resources.*;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.ISaveParticipant;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.PerformanceStats;
+import org.eclipse.core.runtime.Platform;
 
 /**
  * An ResourceStats collects and aggregates timing data about an event such as
@@ -30,12 +35,25 @@ public class ResourceStats {
 	public static final String EVENT_LISTENERS = ResourcesPlugin.PI_RESOURCES + "/perf/listeners"; //$NON-NLS-1$
 	public static final String EVENT_SAVE_PARTICIPANTS = ResourcesPlugin.PI_RESOURCES + "/perf/save.participants"; //$NON-NLS-1$
 	public static final String EVENT_SNAPSHOT = ResourcesPlugin.PI_RESOURCES + "/perf/snapshot"; //$NON-NLS-1$
+	public static final String EVENT_REFRESH = ResourcesPlugin.PI_RESOURCES + "/perf/refresh"; //$NON-NLS-1$
 
 	//performance event enablement
 	public static boolean TRACE_BUILDERS = PerformanceStats.isEnabled(ResourceStats.EVENT_BUILDERS);
 	public static boolean TRACE_LISTENERS = PerformanceStats.isEnabled(ResourceStats.EVENT_LISTENERS);
 	public static boolean TRACE_SAVE_PARTICIPANTS = PerformanceStats.isEnabled(ResourceStats.EVENT_SAVE_PARTICIPANTS);
 	public static boolean TRACE_SNAPSHOT = PerformanceStats.isEnabled(ResourceStats.EVENT_SNAPSHOT);
+	public static boolean TRACE_REFRESH = PerformanceStats.isEnabled(ResourceStats.EVENT_REFRESH);
+	public static int TRACE_REFRESH_THRESHOLD;
+	static {
+		String option = Platform.getDebugOption(ResourceStats.EVENT_REFRESH);
+		if (option != null) {
+			try {
+				TRACE_REFRESH_THRESHOLD = Integer.parseInt(option);
+			} catch (NumberFormatException e) {
+				TRACE_REFRESH_THRESHOLD = 0;
+			}
+		}
+	}
 
 	public static void endBuild() {
 		if (currentStats != null) {
@@ -63,6 +81,15 @@ public class ResourceStats {
 			currentStats.endRun();
 		}
 		currentStats = null;
+	}
+
+	public static PerformanceStats endRefresh() {
+		if (currentStats != null) {
+			currentStats.endRun();
+		}
+		PerformanceStats stats = currentStats;
+		currentStats = null;
+		return stats;
 	}
 
 	/**
@@ -102,4 +129,10 @@ public class ResourceStats {
 		currentStats = PerformanceStats.getStats(EVENT_SAVE_PARTICIPANTS, participant);
 		currentStats.startRun();
 	}
+
+	public static void startRefresh(IResource resource) {
+		currentStats = PerformanceStats.getStats(EVENT_REFRESH, resource);
+		currentStats.startRun();
+	}
+
 }

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/FileSystemResourceManager.java
@@ -36,6 +36,7 @@ import org.eclipse.core.filesystem.IFileInfo;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.filesystem.IFileTree;
 import org.eclipse.core.filesystem.URIUtil;
+import org.eclipse.core.internal.events.ResourceStats;
 import org.eclipse.core.internal.refresh.RefreshManager;
 import org.eclipse.core.internal.resources.File;
 import org.eclipse.core.internal.resources.Folder;
@@ -72,6 +73,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.PerformanceStats;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
@@ -1073,7 +1075,26 @@ public class FileSystemResourceManager implements ICoreConstants, IManager {
 				if (!target.isAccessible()) {
 					return false;
 				}
-				//fall through
+				boolean result;
+				if (ResourceStats.TRACE_REFRESH) {
+					ResourceStats.startRefresh(target);
+				}
+				try {
+					result = refreshResource(target, depth, updateAliases, monitor);
+				} finally {
+					if (ResourceStats.TRACE_REFRESH) {
+						PerformanceStats stats = ResourceStats.endRefresh();
+						if (stats != null) {
+							long runningTime = stats.getRunningTime();
+							if (runningTime > ResourceStats.TRACE_REFRESH_THRESHOLD) {
+								String message = "Refresh on " + target.getFullPath() + " took " + runningTime + " ms"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+								Policy.log(IStatus.INFO, message, null);
+							}
+							stats.reset();
+						}
+					}
+				}
+				return result;
 			case IResource.FOLDER :
 			case IResource.FILE :
 				return refreshResource(target, depth, updateAliases, monitor);


### PR DESCRIPTION
To enable, both runtime tracing options should be enabled:
```
org.eclipse.core.runtime/perf=false
org.eclipse.core.runtime/perf/success=false
```

To change default threshold (500 ms) for reporting to the log, the tracing option below should be changed:
`org.eclipse.core.resources/perf/refresh=500`