### PR TITLE
Use Custom Breakpoint label on Breakpoint listing

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/breakpoints/BreakpointsLabelProvider.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/breakpoints/BreakpointsLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@
 package org.eclipse.debug.internal.ui.views.breakpoints;
 
 import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.model.Breakpoint;
 import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.debug.internal.ui.CompositeDebugImageDescriptor;
 import org.eclipse.debug.internal.ui.DebugUIPlugin;
@@ -78,7 +79,11 @@ public class BreakpointsLabelProvider extends LabelProvider implements IFontProv
 
 	@Override
 	public String getText(Object element) {
-		if (element instanceof IBreakpoint) {
+		if (element instanceof Breakpoint breakpoint) {
+			String customLabel = breakpoint.getBreakpointLabel();
+			if (customLabel != null) {
+				return customLabel;
+			}
 			return fPresentation.getText(element);
 		}
 		return fWorkbenchLabelProvider.getText(element);


### PR DESCRIPTION
Use Custom Breakpoint label on Breakpoint listing for import/export bp

<img width="928" height="164" alt="image" src="https://github.com/user-attachments/assets/ec567a23-76bc-46cf-af1c-3937152df25f" />
