### PR TITLE
Fix concurrent connect in ConsoleColorProvider

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/console/ConsoleColorProvider.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/console/ConsoleColorProvider.java
@@ -38,9 +38,11 @@ public class ConsoleColorProvider implements IConsoleColorProvider {
 	public void connect(IProcess process, IConsole console) {
 		fProcess = process;
 		fConsole = console;
-		IStreamsProxy streamsProxy = fProcess.getStreamsProxy();
+		// Wire up via the arguments, not the fields: a shared provider instance
+		// may be connected concurrently for different processes (issue #2638).
+		IStreamsProxy streamsProxy = process.getStreamsProxy();
 		if (streamsProxy != null) {
-			fConsole.connect(streamsProxy);
+			console.connect(streamsProxy);
 		}
 	}
 


### PR DESCRIPTION
## Problem

The default `ConsoleColorProvider` is shared across `ConsoleCreation` jobs that run in parallel. `connect(IProcess, IConsole)` stored both arguments in the `fProcess`/`fConsole` fields and then wired up via those fields, so concurrent calls could interleave and connect a console to another process' streams proxy. This caused an `ArrayIndexOutOfBoundsException` on the wrong console's stream listeners and consoles not being connected (#2638).

## Fix

Wire up using the method arguments instead of the shared fields.

Independent of the initialization-race fix (#2637); touches only `ConsoleColorProvider`.

Refs #2638