### PR TITLE
Fix ReevaluateExpression enabled state on session termination

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/expressions/ReevaluateWatchExpressionAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/expressions/ReevaluateWatchExpressionAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.model.IDebugElement;
+import org.eclipse.debug.core.model.IDebugTarget;
 import org.eclipse.debug.core.model.IWatchExpression;
 import org.eclipse.debug.internal.ui.DebugUIPlugin;
 import org.eclipse.debug.ui.DebugUITools;
@@ -88,6 +89,11 @@ public class ReevaluateWatchExpressionAction implements IObjectActionDelegate {
 		if (debugElement == null) {
 			action.setEnabled(false);
 		} else {
+			IDebugTarget debugTarget = debugElement.getDebugTarget();
+			if (debugTarget.isDisconnected() || debugTarget.isTerminated()) {
+				action.setEnabled(false);
+				return;
+			}
 			action.setEnabled(true);
 		}
 	}


### PR DESCRIPTION
selectionChanged() now checks whether the debug target is terminated or disconnected before enabling the action, preventing stale re-evaluate actions from being invocable after the debug session has ended.

before 
<img width="945" height="589" alt="Screenshot 2026-07-07 at 5 24 40 PM" src="https://github.com/user-attachments/assets/1387075e-8958-41e7-b967-9da5da94e891" />


After
<img width="959" height="577" alt="Screenshot 2026-07-07 at 5 23 48 PM" src="https://github.com/user-attachments/assets/d2aacc8e-7b24-4ecd-8a35-405341ac08e4" />
