### PR TITLE
Switch external remote ant builder for ant.ui to supported JRE version

### DIFF
--- a/ant/org.eclipse.ant.ui/.externalToolBuilders/Build Remote Ant JAR.launch
+++ b/ant/org.eclipse.ant.ui/.externalToolBuilders/Build Remote Ant JAR.launch
@@ -13,5 +13,5 @@
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/org.eclipse.ant.ui/buildfiles/buildRemoteExtraJAR.xml}"/>
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,incremental,auto,"/>
 <booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </launchConfiguration>

--- a/ant/org.eclipse.ant.ui/META-INF/MANIFEST.MF
+++ b/ant/org.eclipse.ant.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ant.ui; singleton:=true
-Bundle-Version: 3.10.500.qualifier
+Bundle-Version: 3.10.600.qualifier
 Bundle-Activator: org.eclipse.ant.internal.ui.AntUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform/issues/2776 and https://github.com/eclipse-platform/eclipse.platform/pull/1905

Ant support in Eclipse requires Java 17, the remote builder launch config still used 11 which resulted in errors on clean build of the project.

```
eclipse.buildId=4.41.0.I20260712-2300
java.version=25
java.vendor=Eclipse Adoptium
BootLoader constants: OS=linux, ARCH=x86_64, WS=gtk, NL=en_US
Command-line arguments:  -os linux -ws gtk -arch x86_64 -data file:/data/4x_platform_workspace/

org.eclipse.core.externaltools
Error
Mon Jul 13 08:58:45 CEST 2026
Errors running builder 'Integrated External Tool Builder' on project 'org.eclipse.ant.ui'.

org.eclipse.core.runtime.CoreException: JRE version less than 17 is not supported. 
	at org.eclipse.ant.internal.launching.launchConfigurations.AntLaunchDelegate.launch(AntLaunchDelegate.java:138)
	at org.eclipse.debug.internal.core.LaunchConfiguration.launch(LaunchConfiguration.java:790)
	at org.eclipse.debug.internal.core.LaunchConfiguration.launch(LaunchConfiguration.java:701)
	at org.eclipse.debug.internal.core.LaunchConfiguration.launch(LaunchConfiguration.java:696)
	at org.eclipse.core.externaltools.internal.model.ExternalToolBuilder.launchBuild(ExternalToolBuilder.java:188)
	at org.eclipse.core.externaltools.internal.model.ExternalToolBuilder.doBuildBasedOnScope(ExternalToolBuilder.java:176)
	at org.eclipse.core.externaltools.internal.model.ExternalToolBuilder.build(ExternalToolBuilder.java:95)
	at org.eclipse.core.internal.events.BuildManager$2.run(BuildManager.java:1146)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:303)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:363)
	at org.eclipse.core.internal.events.BuildManager$1.run(BuildManager.java:486)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:489)
	at org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:601)
	at org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:549)
	at org.eclipse.core.internal.events.BuildManager.build(BuildManager.java:631)
	at org.eclipse.core.internal.events.AutoBuildJob.doBuild(AutoBuildJob.java:208)
	at org.eclipse.core.internal.events.AutoBuildJob.run(AutoBuildJob.java:309)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)

```