### PR TITLE
Bold Debug view tab on new launch when not focused

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/launch/LaunchView.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/launch/LaunchView.java
@@ -38,6 +38,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchListener;
 import org.eclipse.debug.core.commands.IRestartHandler;
 import org.eclipse.debug.core.model.IDebugTarget;
 import org.eclipse.debug.core.model.IProcess;
@@ -143,7 +144,8 @@ import org.eclipse.ui.texteditor.IUpdate;
 
 public class LaunchView extends AbstractDebugView
 	implements ISelectionChangedListener, IPerspectiveListener2, IPageListener, IShowInTarget, IShowInSource,
-	IShowInTargetList, IPartListener2, IViewerUpdateListener, IContextManagerListener, IModelChangedListener
+	IShowInTargetList, IPartListener2, IViewerUpdateListener, IContextManagerListener, IModelChangedListener,
+	ILaunchListener
 {
 
 	public static final String ID_CONTEXT_ACTIVITY_BINDINGS = "contextActivityBindings"; //$NON-NLS-1$
@@ -883,6 +885,7 @@ public class LaunchView extends AbstractDebugView
 		site.getPage().addPartListener((IPartListener2) this);
 		site.getWorkbenchWindow().addPageListener(this);
 		site.getWorkbenchWindow().addPerspectiveListener(this);
+		DebugPlugin.getDefault().getLaunchManager().addLaunchListener(this);
 	}
 
 	private void preferenceInit(IViewSite site) {
@@ -1058,6 +1061,7 @@ public class LaunchView extends AbstractDebugView
 
 	@Override
 	public void dispose() {
+		DebugPlugin.getDefault().getLaunchManager().removeLaunchListener(this);
 		fContextService.removeContextManagerListener(this);
 		getSite().getSelectionProvider().removeSelectionChangedListener(this);
 		DebugUITools.getDebugContextManager().getContextService(getSite().getWorkbenchWindow()).removeDebugContextProvider(fContextProviderProxy);
@@ -1396,6 +1400,22 @@ public class LaunchView extends AbstractDebugView
 
 	@Override
 	public void partInputChanged(IWorkbenchPartReference partRef) {
+	}
+
+	@Override
+	public void launchAdded(ILaunch launch) {
+		IWorkbenchSiteProgressService progressService = getSite().getAdapter(IWorkbenchSiteProgressService.class);
+		if (progressService != null) {
+			progressService.warnOfContentChange();
+		}
+	}
+
+	@Override
+	public void launchChanged(ILaunch launch) {
+	}
+
+	@Override
+	public void launchRemoved(ILaunch launch) {
 	}
 
 	@Override


### PR DESCRIPTION
When a new launch is added while the Debug view is not the active view, make the Debug view tab label bold to provide a subtle indication that a new launch has started/completed, allowing the user to notice it without manually switching to the Debug view.
<img width="1080" height="608" alt="debug" src="https://github.com/user-attachments/assets/c3e0a34f-50c8-4ed9-b82d-e5def133c8f4" />
