### PR TITLE
Show ancestor pane of 3-way preview in Compare pref page

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ComparePreferencePage.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/ComparePreferencePage.java
@@ -426,6 +426,7 @@ public class ComparePreferencePage extends PreferencePage implements IWorkbenchP
 
 	private Control create3WayPreviewer(Composite parent) {
 		CompareConfiguration compareConfiguration = new CompareConfiguration(fOverlayStore);
+		compareConfiguration.setProperty(ICompareUIConstants.PROP_ANCESTOR_VISIBLE, Boolean.TRUE);
 		compareConfiguration.setAncestorLabel(Utilities.getString("ComparePreferencePage.ancestor.label")); //$NON-NLS-1$
 
 		compareConfiguration.setLeftLabel(Utilities.getString("ComparePreferencePage.left.label")); //$NON-NLS-1$


### PR DESCRIPTION
The 3-way preview's CompareConfiguration never showed the Common Ancestor pane, since the property controlling its visibility was never set. Explicitly set PROP_ANCESTOR_VISIBLE to true on the preview's CompareConfiguration so the ancestor pane is shown.

Before : 
<img width="900" height="274" alt="image" src="https://github.com/user-attachments/assets/fc431879-0ffe-4bae-b6b3-10e2a7dfbee5" />


After : 
<img width="1540" height="257" alt="image" src="https://github.com/user-attachments/assets/caeda431-d467-498f-ad5d-d6c0e62d5bed" />

Steps to reproduce : 

Goto -> Preference -> Compare and patch -> Text Compare

<img width="1113" height="990" alt="image" src="https://github.com/user-attachments/assets/70c4f6ab-bcc3-45a3-beac-7044386115c1" />

Version: 2026-09 (4.41)
Build id: I20260703-1319
