### PR TITLE
Force qualifier changes for org.eclipse.compare.core

### DIFF
--- a/team/bundles/org.eclipse.compare.core/forceQualifierUpdate.txt
+++ b/team/bundles/org.eclipse.compare.core/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/11
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3190
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3927


### PR DESCRIPTION
- It shares a split package with org.eclipse.compare.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3927