### PR TITLE
Switch external ant builder for ant.launching to supported JRE version

### DIFF
--- a/ant/org.eclipse.ant.launching/.externalToolBuilders/build loggers [Builder].launch
+++ b/ant/org.eclipse.ant.launching/.externalToolBuilders/build loggers [Builder].launch
@@ -19,5 +19,5 @@
 <stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,incremental,auto,"/>
 <booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
 <stringAttribute key="process_factory_id" value="org.eclipse.ant.ui.remoteAntProcessFactory"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </launchConfiguration>


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform/issues/2776 and https://github.com/eclipse-platform/eclipse.platform/pull/1905

Ant support in Eclipse requires Java 17, the remote builder launch config still used 11 which resulted in errors on clean build of the project.