### PR TITLE
Do not show error dialog when validateEdit fails for Unified Diff

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
@@ -146,8 +146,6 @@ public final class CompareMessages extends NLS {
 	public static String UnifiedDiff_undo;
 	public static String UnifiedDiff_revert;
 	public static String UnifiedDiff_openTwoWayCompare_tooltip;
-	public static String UnifiedDiff_cannotEditFile_title;
-	public static String UnifiedDiff_cannotEditFile_message;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, CompareMessages.class);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
@@ -161,5 +161,3 @@ UnifiedDiff_keep=Keep
 UnifiedDiff_undo=Undo
 UnifiedDiff_revert=Revert
 UnifiedDiff_openTwoWayCompare_tooltip=Open in 2-way Compare Editor
-UnifiedDiff_cannotEditFile_title=Cannot edit file
-UnifiedDiff_cannotEditFile_message=Cannot edit file {0}: {1}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffManager.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffManager.java
@@ -48,7 +48,6 @@ import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.action.ToolBarManager;
-import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -68,7 +67,6 @@ import org.eclipse.jface.text.source.IAnnotationModelListenerExtension;
 import org.eclipse.jface.text.source.ISourceViewerExtension5;
 import org.eclipse.jface.text.source.inlined.AbstractInlinedAnnotation;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
-import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.ControlEvent;
@@ -1295,11 +1293,6 @@ public class UnifiedDiffManager {
 				if (status != null) {
 					if (status.isOK()) {
 						result[0] = true;
-					} else {
-						MessageDialog.openError(Display.getDefault().getActiveShell(),
-								CompareMessages.UnifiedDiff_cannotEditFile_title,
-								NLS.bind(CompareMessages.UnifiedDiff_cannotEditFile_message, fFile.getFullPath(),
-										status.getMessage()));
 					}
 				}
 			}, new NullProgressMonitor());


### PR DESCRIPTION
Unified Diff cannot be applied when the current editor content is read-only and not modifiable. In that case validateEdit fails and open() returns CANCEL_STATUS, so the caller falls back to opening the existing two-way diff editor. Showing an error dialog on top of that fallback was more irritating than helpful, so it is removed.