### PR TITLE
Guard the preference store again in openCompareEditor

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -574,11 +574,11 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 		CompareConfiguration configuration = input.getCompareConfiguration();
 		if (configuration != null) {
 			IPreferenceStore ps= configuration.getPreferenceStore();
-			boolean unifiedDiffEnabled = ps.getBoolean(ComparePreferencePage.UNIFIED_DIFF);
-			if (unifiedDiffEnabled && openUnifiedDiffInEditor(input, page, editor, activate)) {
-				return;
-			}
 			if (ps != null) {
+				if (ps.getBoolean(ComparePreferencePage.UNIFIED_DIFF)
+						&& openUnifiedDiffInEditor(input, page, editor, activate)) {
+					return;
+				}
 				configuration.setProperty(
 						CompareConfiguration.USE_OUTLINE_VIEW,
 						Boolean.valueOf(ps.getBoolean(ComparePreferencePage.USE_OUTLINE_VIEW)));


### PR DESCRIPTION
The unified diff check added to `CompareUIPlugin#openCompareEditor` dereferences the compare configuration's preference store before the null guard that immediately follows it. A `CompareConfiguration` without a preference store is a supported state, so every compare editor open for such a configuration now fails with a NullPointerException.

This moves the unified diff check inside the existing `if (ps != null)` block. Behavior is unchanged whenever a preference store is present.