### PR TITLE
Open the unified diff without blocking the UI thread

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
@@ -146,6 +146,7 @@ public final class CompareMessages extends NLS {
 	public static String UnifiedDiff_undo;
 	public static String UnifiedDiff_revert;
 	public static String UnifiedDiff_openTwoWayCompare_tooltip;
+	public static String UnifiedDiff_preparing;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, CompareMessages.class);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
@@ -161,3 +161,4 @@ UnifiedDiff_keep=Keep
 UnifiedDiff_undo=Undo
 UnifiedDiff_revert=Revert
 UnifiedDiff_openTwoWayCompare_tooltip=Open in 2-way Compare Editor
+UnifiedDiff_preparing=Preparing Unified Diff for {0}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -79,6 +79,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.content.IContentDescription;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.core.runtime.content.IContentTypeManager;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.operation.IRunnableContext;
@@ -88,6 +89,7 @@ import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.osgi.service.debug.DebugOptions;
 import org.eclipse.osgi.service.debug.DebugOptionsListener;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
@@ -595,11 +597,21 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 		CompareConfiguration configuration = input.getCompareConfiguration();
 		if (configuration != null) {
 			IPreferenceStore ps= configuration.getPreferenceStore();
+			if (ps != null && ps.getBoolean(ComparePreferencePage.UNIFIED_DIFF)) {
+				openUnifiedDiffInEditor(input, page, editor, activate);
+				return;
+			}
+		}
+		openClassicCompareEditor(input, page, editor, activate);
+	}
+
+	/** Opens the classic side by side compare editor on the given input. */
+	private void openClassicCompareEditor(final CompareEditorInput input, final IWorkbenchPage page,
+			final IReusableEditor editor, final boolean activate) {
+		CompareConfiguration configuration = input.getCompareConfiguration();
+		if (configuration != null) {
+			IPreferenceStore ps= configuration.getPreferenceStore();
 			if (ps != null) {
-				if (ps.getBoolean(ComparePreferencePage.UNIFIED_DIFF)
-						&& openUnifiedDiffInEditor(input, page, editor, activate)) {
-					return;
-				}
 				configuration.setProperty(
 						CompareConfiguration.USE_OUTLINE_VIEW,
 						Boolean.valueOf(ps.getBoolean(ComparePreferencePage.USE_OUTLINE_VIEW)));
@@ -614,76 +626,108 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 		}
 	}
 
-	private boolean openUnifiedDiffInEditor(final CompareEditorInput input, final IWorkbenchPage page,
-			IReusableEditor editor, boolean activate) {
-		var unifiedDiffInput = canShowInUnifiedDiff(input);
-		if (unifiedDiffInput!=null) {
-			try {
-				IWorkbenchPage wpage = page != null ? page : getActivePage();
-				if (wpage == null) {
-					// no active workbench page; fall back to the classic compare editor path
-					return false;
+	/**
+	 * Prepares the input in a background job and opens the unified diff on the
+	 * result, falling back to the classic compare editor when the input does not
+	 * qualify or no text editor can be opened for it.
+	 */
+	private void openUnifiedDiffInEditor(final CompareEditorInput input, final IWorkbenchPage page,
+			final IReusableEditor editor, final boolean activate) {
+		if (!input.canRunAsJob()) {
+			openUnifiedDiffOrFallback(prepareUnifiedDiff(input, new NullProgressMonitor()), input, page, editor,
+					activate);
+			return;
+		}
+		Job job = new Job(NLS.bind(CompareMessages.UnifiedDiff_preparing, input.getTitle())) {
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				UnifiedDiffSource source;
+				try {
+					source = prepareUnifiedDiff(input, monitor);
+				} catch (OperationCanceledException e) {
+					return Status.CANCEL_STATUS;
 				}
-				if (unifiedDiffInput.left instanceof IFileEditorInput) {
-					IEditorPart leftEditor = wpage.openEditor(unifiedDiffInput.left,
-							getEditorId(unifiedDiffInput.left, unifiedDiffInput.leftElement));
-					if (leftEditor instanceof MultiPageEditorPart mpe) {
-						Object p = mpe.getSelectedPage();
-						if (p instanceof IEditorPart) {
-							leftEditor = (IEditorPart) p;
-						}
-					}
-					if (leftEditor instanceof ITextEditor leftTextEditor) {
-						Action openTwoWayCompare = createOpenTwoWayCompareAction(input, page, editor, activate,
-								leftTextEditor);
-						IStatus status = UnifiedDiff
-								.create(leftTextEditor, getSourceOf(unifiedDiffInput.rightAcessor()),
-										UnifiedDiffMode.REVERT_MODE)
-								.additionalActions(Arrays.asList(openTwoWayCompare))
-								.ignoreWhitespaceContributorFactory(t -> unifiedDiffInput.documentMergerInput != null
-										? unifiedDiffInput.documentMergerInput.createIgnoreWhitespaceContributor(t)
-										: Optional.empty())
-								.tokenComparatorFactory(t -> unifiedDiffInput.documentMergerInput != null
-										? unifiedDiffInput.documentMergerInput.createTokenComparator(t)
-										: null)
-								.ignoreWhiteSpace(Utilities.getBoolean(input.getCompareConfiguration(),
-										CompareConfiguration.IGNORE_WHITESPACE, false))
-								.open();
-						return status.isOK();
-					}
-				} else {
-					IEditorPart rightEditor = wpage.openEditor(unifiedDiffInput.right,
-							getEditorId(unifiedDiffInput.right, unifiedDiffInput.rightElement));
-					if (rightEditor instanceof MultiPageEditorPart mpe) {
-						Object p = mpe.getSelectedPage();
-						if (p instanceof IEditorPart) {
-							rightEditor = (IEditorPart) p;
-						}
-					}
-					if (rightEditor instanceof ITextEditor rightTextEditor) {
-						Action openTwoWayCompare = createOpenTwoWayCompareAction(input, page, editor, activate,
-								rightTextEditor);
-						IStatus status = UnifiedDiff
-								.create(rightTextEditor, getSourceOf(unifiedDiffInput.leftAcessor()),
-										UnifiedDiffMode.OVERLAY_READ_ONLY_MODE)
-								.additionalActions(Arrays.asList(openTwoWayCompare))
-								.ignoreWhitespaceContributorFactory(t -> unifiedDiffInput.documentMergerInput != null
-										? unifiedDiffInput.documentMergerInput.createIgnoreWhitespaceContributor(t)
-										: Optional.empty())
-								.tokenComparatorFactory(t -> unifiedDiffInput.documentMergerInput != null
-										? unifiedDiffInput.documentMergerInput.createTokenComparator(t)
-										: null)
-								.ignoreWhiteSpace(Utilities.getBoolean(input.getCompareConfiguration(),
-										CompareConfiguration.IGNORE_WHITESPACE, false))
-								.open();
-						return status.isOK();
-					}
+				if (monitor.isCanceled()) {
+					return Status.CANCEL_STATUS;
 				}
-			} catch (PartInitException e) {
-				CompareUIPlugin.log(e);
+				Display.getDefault().asyncExec(() -> openUnifiedDiffOrFallback(source, input, page, editor, activate));
+				return Status.OK_STATUS;
 			}
+
+			@Override
+			public boolean belongsTo(Object family) {
+				return family == input || input.belongsTo(family);
+			}
+		};
+		job.setUser(true);
+		job.schedule();
+	}
+
+	private void openUnifiedDiffOrFallback(UnifiedDiffSource source, CompareEditorInput input, IWorkbenchPage page,
+			IReusableEditor editor, boolean activate) {
+		if (source == null || !openUnifiedDiff(source, input, page, editor, activate)) {
+			openClassicCompareEditor(input, page, editor, activate);
+		}
+	}
+
+	private boolean openUnifiedDiff(UnifiedDiffSource source, CompareEditorInput input, IWorkbenchPage page,
+			IReusableEditor editor, boolean activate) {
+		IWorkbenchPage wpage = page != null ? page : getActivePage();
+		if (wpage == null) {
+			// no active workbench page; fall back to the classic compare editor path
+			return false;
+		}
+		try {
+			IDocumentMergerInput mergerInput = findDocumentMergerInput(input, source.compareInput());
+			IEditorPart editorPart = wpage.openEditor(source.editorInput(),
+					getEditorId(source.editorInput(), source.element()));
+			if (editorPart instanceof MultiPageEditorPart mpe && mpe.getSelectedPage() instanceof IEditorPart selected) {
+				editorPart = selected;
+			}
+			if (!(editorPart instanceof ITextEditor textEditor)) {
+				return false;
+			}
+			Action openTwoWayCompare = createOpenTwoWayCompareAction(input, page, editor, activate, textEditor);
+			IStatus status = UnifiedDiff.create(textEditor, source.diffSource(), source.mode())
+					.additionalActions(Arrays.asList(openTwoWayCompare))
+					.ignoreWhitespaceContributorFactory(
+							t -> mergerInput != null ? mergerInput.createIgnoreWhitespaceContributor(t)
+									: Optional.empty())
+					.tokenComparatorFactory(t -> mergerInput != null ? mergerInput.createTokenComparator(t) : null)
+					.ignoreWhiteSpace(Utilities.getBoolean(input.getCompareConfiguration(),
+							CompareConfiguration.IGNORE_WHITESPACE, false))
+					.open();
+			return status.isOK();
+		} catch (PartInitException e) {
+			CompareUIPlugin.log(e);
 		}
 		return false;
+	}
+
+	/**
+	 * Returns the token comparator and whitespace factories of a registered custom
+	 * merge viewer, or <code>null</code> when the platform's own text merge viewer
+	 * applies. Only a custom viewer is instantiated, because the unified diff
+	 * already defaults to what the platform viewer would contribute.
+	 */
+	private IDocumentMergerInput findDocumentMergerInput(CompareEditorInput input, ICompareInput compareInput) {
+		ViewerDescriptor[] descriptors = findContentViewerDescriptor(null, compareInput,
+				input.getCompareConfiguration());
+		if (descriptors == null || descriptors.length == 0
+				|| TextMergeViewerCreator.class.getName().equals(descriptors[0].getViewerClass())) {
+			return null;
+		}
+		Shell invisibleParent = new Shell();
+		try {
+			invisibleParent.setVisible(false);
+			Viewer viewer = input.findContentViewer(new NullViewer(invisibleParent), compareInput, invisibleParent);
+			if (viewer instanceof IAdaptable adaptable) {
+				return adaptable.getAdapter(IDocumentMergerInput.class);
+			}
+		} finally {
+			invisibleParent.dispose();
+		}
+		return null;
 	}
 
 	private Action createOpenTwoWayCompareAction(final CompareEditorInput input, final IWorkbenchPage page,
@@ -746,67 +790,53 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 		return id;
 	}
 
-	private static record LeftEditorInputAndRightStreamContentAccessor(IEditorInput left, ITypedElement leftElement,
-			IStreamContentAccessor leftAcessor, IEditorInput right, ITypedElement rightElement,
-			IStreamContentAccessor rightAcessor, IDocumentMergerInput documentMergerInput) {
+	/** The editor to open, plus the side that is overlaid onto it as a diff. */
+	private static record UnifiedDiffSource(ICompareInput compareInput, IEditorInput editorInput,
+			ITypedElement element, UnifiedDiffMode mode, String diffSource) {
 	}
 
-	private LeftEditorInputAndRightStreamContentAccessor canShowInUnifiedDiff(CompareEditorInput input) {
-		IDocumentMergerInput documentMergerInput = null;
+	/**
+	 * Runs the input and collects what the unified diff needs, off the UI thread.
+	 * Returns <code>null</code> if the input cannot be shown as a unified diff.
+	 */
+	private UnifiedDiffSource prepareUnifiedDiff(CompareEditorInput input, IProgressMonitor monitor) {
 		try {
-			input.run(new NullProgressMonitor());
-			Object res = input.getCompareResult();
-			if (!(res instanceof ICompareInput compareInput)) {
-				return null;
-			}
-			// A common ancestor (3-way input) is ignored; the unified diff renders a
-			// plain left-vs-right overlay.
-			ITypedElement left = compareInput.getLeft();
-			if (left == null) {
-				return null;
-			}
-			ISharedDocumentAdapter leftSda = SharedDocumentAdapterWrapper.getAdapter(left);
-			if (leftSda == null) {
-				return null;
-			}
-			IEditorInput leftEditorInput = leftSda.getDocumentKey(left);
-			if (leftEditorInput == null) {
-				return null;
-			}
-			if (!(left instanceof IStreamContentAccessor leftSa)) {
-				return null;
-			}
-			ITypedElement right = compareInput.getRight();
-			if (right == null) {
-				return null;
-			}
-			ISharedDocumentAdapter rightSda = SharedDocumentAdapterWrapper.getAdapter(right);
-			if (rightSda == null) {
-				return null;
-			}
-			IEditorInput rightEditorInput = rightSda.getDocumentKey(right);
-			if (rightEditorInput == null) {
-				return null;
-			}
-			if (!(right instanceof IStreamContentAccessor rightSa)) {
-				return null;
-			}
-			var invisibleParent = new Shell();
-			try {
-				invisibleParent.setVisible(false);
-				var viewer = input.findContentViewer(new NullViewer(invisibleParent), compareInput, invisibleParent);
-				if (viewer instanceof IAdaptable adaptable) {
-					documentMergerInput = adaptable.getAdapter(IDocumentMergerInput.class);
-				}
-			} finally {
-				invisibleParent.dispose();
-			}
-			return new LeftEditorInputAndRightStreamContentAccessor(leftEditorInput, left, leftSa, rightEditorInput,
-					right, rightSa, documentMergerInput);
-		} catch (InvocationTargetException | InterruptedException e) {
+			input.run(monitor);
+		} catch (InterruptedException e) {
+			throw new OperationCanceledException();
+		} catch (InvocationTargetException e) {
 			CompareUIPlugin.log(e);
+			return null;
 		}
-		return null;
+		if (!(input.getCompareResult() instanceof ICompareInput compareInput)) {
+			return null;
+		}
+		// A common ancestor (3-way input) is ignored; the unified diff renders a
+		// plain left-vs-right overlay.
+		ITypedElement left = compareInput.getLeft();
+		ITypedElement right = compareInput.getRight();
+		IEditorInput leftEditorInput = documentKeyOf(left);
+		IEditorInput rightEditorInput = documentKeyOf(right);
+		if (leftEditorInput == null || rightEditorInput == null || !(left instanceof IStreamContentAccessor leftSource)
+				|| !(right instanceof IStreamContentAccessor rightSource)) {
+			return null;
+		}
+		// The side that is not shown in the editor supplies the diff source, so it is
+		// read here instead of on the UI thread.
+		if (leftEditorInput instanceof IFileEditorInput) {
+			return new UnifiedDiffSource(compareInput, leftEditorInput, left, UnifiedDiffMode.REVERT_MODE,
+					getSourceOf(rightSource));
+		}
+		return new UnifiedDiffSource(compareInput, rightEditorInput, right, UnifiedDiffMode.OVERLAY_READ_ONLY_MODE,
+				getSourceOf(leftSource));
+	}
+
+	private static IEditorInput documentKeyOf(ITypedElement element) {
+		if (element == null) {
+			return null;
+		}
+		ISharedDocumentAdapter adapter = SharedDocumentAdapterWrapper.getAdapter(element);
+		return adapter == null ? null : adapter.getDocumentKey(element);
 	}
 
 	private void openEditorInBackground(final CompareEditorInput input, final IWorkbenchPage page,

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/CompareOpenEfficiencyTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/CompareOpenEfficiencyTest.java
@@ -222,15 +222,13 @@ public class CompareOpenEfficiencyTest {
 				"prepareInput must run off the UI thread when the input can run as a job"); //$NON-NLS-1$
 	}
 
-	// Documents current behavior: the unified diff path prepares the input on the
-	// UI thread. This assertion flips once the preparation moves to a background job.
 	@Test
-	public void testPrepareInputOnUiThreadUnifiedOnDocumentsCurrentBehavior() throws Exception {
+	public void testPrepareInputOffUiThreadUnifiedOn() throws Exception {
 		store().setValue(ComparePreferencePage.UNIFIED_DIFF, true);
 		CountingCompareEditorInput input = openAndWait(true);
 		assertTrue(input.prepareInputCalls() >= 1, "prepareInput did not run"); //$NON-NLS-1$
-		assertEquals(true, input.ranOnUiThread(),
-				"documents current behavior: unified diff runs prepareInput on the UI thread (Phase 1 item 3)"); //$NON-NLS-1$
+		assertEquals(false, input.ranOnUiThread(),
+				"the unified diff path must prepare the input off the UI thread"); //$NON-NLS-1$
 	}
 
 	private CountingCompareEditorInput openAndWait(boolean runAsJob) throws Exception {

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/UnifiedDiffOpenTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/UnifiedDiffOpenTest.java
@@ -249,14 +249,12 @@ public class UnifiedDiffOpenTest {
 		assertEquals(1, input.prepareInputCount.get(), "prepareInput must run exactly once per unified open"); //$NON-NLS-1$
 	}
 
-	// Documents current behavior: the unified diff path prepares the input on the
-	// UI thread. This assertion flips once the preparation moves to a background job.
 	@Test
-	public void testUnifiedOpenRunsPrepareInputOnUiThreadDocumentsCurrentBehavior() throws Exception {
+	public void testUnifiedOpenRunsPrepareInputOffUiThread() throws Exception {
 		RecordingCompareEditorInput input = openQualifyingInput();
 		assertTrue(input.prepareInputCount.get() >= 1, "prepareInput did not run"); //$NON-NLS-1$
-		assertEquals(true, input.anyRunOnUiThread,
-				"documents current behavior: the unified diff path runs prepareInput on the UI thread"); //$NON-NLS-1$
+		assertEquals(false, input.anyRunOnUiThread,
+				"the unified diff path must prepare the input off the UI thread"); //$NON-NLS-1$
 	}
 
 	@Test


### PR DESCRIPTION
With the unified diff preference enabled, opening a compare editor ran the full `prepareInput` synchronously on the UI thread with a `NullProgressMonitor`, and read the whole opposite side of the comparison there as well. The preparation now runs in a cancelable job, the same way the classic compare editor already works; only opening the text editor and applying the diff stay on the UI thread. Progress and cancellation are visible to the user instead of a frozen workbench, and when the input does not qualify the classic editor reuses the already prepared result rather than comparing a second time.

Obtaining the token comparator and the ignore-whitespace contributor no longer builds a throwaway `TextMergeViewer` on an invisible shell. The unified diff already falls back to exactly what the platform text merge viewer contributes, so that viewer is only created when a custom merge viewer is registered for the content type.

The two tests that documented the old on-the-UI-thread behavior now assert the opposite.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/2795