### PR TITLE
Let the user cancel the unified diff computation

### DIFF
--- a/team/bundles/org.eclipse.compare.core/src/org/eclipse/compare/rangedifferencer/RangeDifferencer.java
+++ b/team/bundles/org.eclipse.compare.core/src/org/eclipse/compare/rangedifferencer/RangeDifferencer.java
@@ -81,7 +81,7 @@ public final class RangeDifferencer {
 	 * @since 2.0
 	 */
 	public static RangeDifference[] findDifferences(IProgressMonitor pm, IRangeComparator left, IRangeComparator right) {
-		return findDifferences(defaultFactory, null, left, right);
+		return findDifferences(defaultFactory, pm, left, right);
 	}
 
 	/**

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.java
@@ -147,6 +147,7 @@ public final class CompareMessages extends NLS {
 	public static String UnifiedDiff_revert;
 	public static String UnifiedDiff_openTwoWayCompare_tooltip;
 	public static String UnifiedDiff_preparing;
+	public static String UnifiedDiff_computing;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, CompareMessages.class);

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareMessages.properties
@@ -162,3 +162,4 @@ UnifiedDiff_undo=Undo
 UnifiedDiff_revert=Revert
 UnifiedDiff_openTwoWayCompare_tooltip=Open in 2-way Compare Editor
 UnifiedDiff_preparing=Preparing Unified Diff for {0}
+UnifiedDiff_computing=Computing Unified Diff

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -60,6 +60,7 @@ import org.eclipse.compare.structuremergeviewer.StructureDiffViewer;
 import org.eclipse.compare.unifieddiff.UnifiedDiff;
 import org.eclipse.compare.unifieddiff.UnifiedDiffMode;
 import org.eclipse.compare.unifieddiff.internal.HideAllDiffsRunnable;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.Adapters;
@@ -697,7 +698,9 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 					.ignoreWhiteSpace(Utilities.getBoolean(input.getCompareConfiguration(),
 							CompareConfiguration.IGNORE_WHITESPACE, false))
 					.open();
-			return status.isOK();
+			// The user canceled the diff, not the open: leave the text editor alone
+			// instead of falling back to the classic compare editor.
+			return status.isOK() || status.getCode() == UnifiedDiffManager.CANCELED_BY_USER_CODE;
 		} catch (PartInitException e) {
 			CompareUIPlugin.log(e);
 		}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffManager.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffManager.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.compare.unifieddiff.internal;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -38,10 +39,13 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
@@ -93,6 +97,7 @@ import org.eclipse.text.undo.DocumentUndoManagerRegistry;
 import org.eclipse.text.undo.IDocumentUndoListener;
 import org.eclipse.text.undo.IDocumentUndoManager;
 import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 public class UnifiedDiffManager {
@@ -107,6 +112,16 @@ public class UnifiedDiffManager {
 	private static final String TOOLBAR_COMPOSITE_FOR_ONE_DIFF_KEY = "TOOLBAR_COMPOSITE_FOR_ONE_DIFF_KEY"; //$NON-NLS-1$
 	private static final String TOOLBAR_COMPOSITE_FOR_ALL_DIFFS_KEY = "TOOLBAR_COMPOSITE_FOR_ALL_DIFFS_KEY"; //$NON-NLS-1$
 	private static final Map<ITextViewer, List<UnifiedDiff>> diffsByViewer = new HashMap<>();
+
+	/** Status code reported when the user canceled the diff computation. */
+	public static final int CANCELED_BY_USER_CODE = 1;
+
+	/**
+	 * The user canceled the computation. The text editor is already open, so the
+	 * caller must not fall back to the classic compare editor.
+	 */
+	private static final IStatus CANCELED_BY_USER = new Status(IStatus.CANCEL, UnifiedDiffManager.class,
+			CANCELED_BY_USER_CODE, "canceled by the user", null); //$NON-NLS-1$
 
 	public static void put(ITextViewer viewer, List<UnifiedDiff> diffs) {
 		diffsByViewer.put(viewer, diffs);
@@ -132,103 +147,12 @@ public class UnifiedDiffManager {
 		IDocument leftDocument = editor.getDocumentProvider().getDocument(editor.getEditorInput());
 		IDocument rightDocument = new Document(source);
 
-		DocLineComparator left = null, right = null;
-		Optional<IIgnoreWhitespaceContributor> lDocIgnonerWhitespaceContributor = Optional.empty();
-		Optional<IIgnoreWhitespaceContributor> rDocIgnonreWhitespaceContributor = Optional.empty();
-		if (ignoreWhitespaceContributorFactory != null) {
-			lDocIgnonerWhitespaceContributor = ignoreWhitespaceContributorFactory.apply(leftDocument);
-			left = new DocLineComparator(leftDocument, null, ignoreWhiteSpace, null, '?',
-					lDocIgnonerWhitespaceContributor);
-			rDocIgnonreWhitespaceContributor = ignoreWhitespaceContributorFactory.apply(rightDocument);
-			right = new DocLineComparator(rightDocument, null, ignoreWhiteSpace, null, '?',
-					rDocIgnonreWhitespaceContributor);
-		} else {
-			left = new DocLineComparator(leftDocument, null, ignoreWhiteSpace);
-			right = new DocLineComparator(rightDocument, null, ignoreWhiteSpace);
-		}
-		List<UnifiedDiff> unifiedDiffs = new ArrayList<>();
-		RangeDifference[] rangeDiffs = RangeDifferencer.findDifferences(left, right);
-		for (RangeDifference rangeDiff : rangeDiffs) {
-			try {
-				int leftStart = left.getTokenStart(rangeDiff.leftStart());
-				int leftEnd = getTokenEnd(left, rangeDiff.leftStart(), rangeDiff.leftLength());
-				String leftDiffSource = leftDocument.get(leftStart, leftEnd - leftStart);
-
-				int rightStart = right.getTokenStart(rangeDiff.rightStart());
-				int rightEnd = getTokenEnd(right, rangeDiff.rightStart(), rangeDiff.rightLength());
-				String rightDiffSource = rightDocument.get(rightStart, rightEnd - rightStart);
-
-				if (leftDiffSource.length() == 0 && rightDiffSource.length() == 0) {
-					continue;
-				}
-				boolean isWhitespace = false;
-				// Indicate whether all contributors are whitespace
-				if (ignoreWhiteSpace && leftDiffSource.trim().length() == 0 && rightDiffSource.trim().length() == 0) {
-					isWhitespace = true;
-
-					// Check if whitespace can be ignored by the contributor
-					if (leftDiffSource.length() > 0 && !lDocIgnonerWhitespaceContributor.isEmpty()) {
-						boolean isIgnored = lDocIgnonerWhitespaceContributor.get()
-								.isIgnoredWhitespace(rangeDiff.leftStart(), rangeDiff.leftLength());
-						isWhitespace = isIgnored;
-					}
-					if (isWhitespace && rightDiffSource.length() > 0 && !rDocIgnonreWhitespaceContributor.isEmpty()) {
-						boolean isIgnored = rDocIgnonreWhitespaceContributor.get()
-								.isIgnoredWhitespace(rangeDiff.rightStart(), rangeDiff.rightLength());
-						isWhitespace = isIgnored;
-					}
-				}
-				if (isWhitespace) {
-					continue;
-				}
-				int kind = rangeDiff.kind();
-				switch (kind) {
-				case RangeDifference.NOCHANGE:
-					break;
-				case RangeDifference.CHANGE:
-					var diff = new UnifiedDiff(leftDocument, leftStart, leftEnd, leftDiffSource, rightDocument,
-							rightStart, rightEnd, rightDiffSource, unifiedDiffs, mode);
-					unifiedDiffs.add(diff);
-
-					// line based fine granular diff via DocumentMerger#simpleTokenDiff
-					ITokenComparator l = createTokenComparator(leftDiffSource, tokenComparatorFactory);
-					ITokenComparator r = createTokenComparator(rightDiffSource, tokenComparatorFactory);
-					RangeDifference[] detailedDiffs = RangeDifferencer.findRanges((IRangeComparator) null, l, r);
-					for (RangeDifference detailedDiff : detailedDiffs) {
-						if (detailedDiff.kind() == RangeDifference.NOCHANGE) {
-							continue;
-						}
-						int detailedLeftStart = l.getTokenStart(detailedDiff.leftStart());
-						int detailedLeftEnd = getTokenEnd(l, detailedDiff.leftStart(), detailedDiff.leftLength());
-						String detailedLeftDiffSource = leftDiffSource.substring(detailedLeftStart, detailedLeftEnd);
-
-						int detailedRightStart = r.getTokenStart(detailedDiff.rightStart());
-						int detailedRightEnd = getTokenEnd(r, detailedDiff.rightStart(), detailedDiff.rightLength());
-						String detailedDiffRightDiffSource = rightDiffSource.substring(detailedRightStart,
-								detailedRightEnd);
-						if (detailedLeftDiffSource.trim().length() == 0
-								&& detailedDiffRightDiffSource.trim().length() == 0) {
-							continue;
-						}
-						diff.detailedDiffs.add(new UnifiedDiff(leftDocument, detailedLeftStart, detailedLeftEnd,
-								detailedLeftDiffSource, rightDocument, detailedRightStart, detailedRightEnd,
-								detailedDiffRightDiffSource, unifiedDiffs, mode));
-					}
-					break;
-				case RangeDifference.CONFLICT:
-					break;
-				case RangeDifference.LEFT:
-					break;
-				case RangeDifference.ERROR:
-					break;
-				case RangeDifference.ANCESTOR:
-					break;
-				default:
-					break;
-				}
-			} catch (BadLocationException e) {
-				error(e);
-			}
+		List<UnifiedDiff> unifiedDiffs;
+		try {
+			unifiedDiffs = computeDiffsWithProgress(leftDocument, rightDocument, mode, tokenComparatorFactory,
+					ignoreWhitespaceContributorFactory, ignoreWhiteSpace);
+		} catch (OperationCanceledException | InterruptedException e) {
+			return CANCELED_BY_USER;
 		}
 		// call validateEdit before modifying the leftDocument; in read-only overlay
 		// mode the document is not modified, so skip the check to avoid prompting
@@ -428,6 +352,135 @@ public class UnifiedDiffManager {
 		@Override
 		public void modelChanged(IAnnotationModel model) {
 		}
+	}
+
+	/**
+	 * Computes the line differences and their token differences with a cancelable
+	 * progress monitor, so that a large file does not block the editor silently.
+	 */
+	private static List<UnifiedDiff> computeDiffsWithProgress(IDocument leftDocument, IDocument rightDocument,
+			UnifiedDiffMode mode, TokenComparatorFactory tokenComparatorFactory,
+			IgnoreWhitespaceContributorFactory ignoreWhitespaceContributorFactory, boolean ignoreWhiteSpace)
+			throws InterruptedException {
+		List<List<UnifiedDiff>> computed = new ArrayList<>(1);
+		try {
+			PlatformUI.getWorkbench().getProgressService()
+					.busyCursorWhile(monitor -> computed.add(computeDiffs(leftDocument, rightDocument, mode,
+							tokenComparatorFactory, ignoreWhitespaceContributorFactory, ignoreWhiteSpace, monitor)));
+		} catch (InvocationTargetException e) {
+			error(e);
+			return List.of();
+		}
+		return computed.isEmpty() ? List.of() : computed.get(0);
+	}
+
+	private static List<UnifiedDiff> computeDiffs(IDocument leftDocument, IDocument rightDocument, UnifiedDiffMode mode,
+			TokenComparatorFactory tokenComparatorFactory,
+			IgnoreWhitespaceContributorFactory ignoreWhitespaceContributorFactory, boolean ignoreWhiteSpace,
+			IProgressMonitor monitor) {
+		DocLineComparator left = null, right = null;
+		Optional<IIgnoreWhitespaceContributor> lDocIgnonerWhitespaceContributor = Optional.empty();
+		Optional<IIgnoreWhitespaceContributor> rDocIgnonreWhitespaceContributor = Optional.empty();
+		if (ignoreWhitespaceContributorFactory != null) {
+			lDocIgnonerWhitespaceContributor = ignoreWhitespaceContributorFactory.apply(leftDocument);
+			left = new DocLineComparator(leftDocument, null, ignoreWhiteSpace, null, '?',
+					lDocIgnonerWhitespaceContributor);
+			rDocIgnonreWhitespaceContributor = ignoreWhitespaceContributorFactory.apply(rightDocument);
+			right = new DocLineComparator(rightDocument, null, ignoreWhiteSpace, null, '?',
+					rDocIgnonreWhitespaceContributor);
+		} else {
+			left = new DocLineComparator(leftDocument, null, ignoreWhiteSpace);
+			right = new DocLineComparator(rightDocument, null, ignoreWhiteSpace);
+		}
+		List<UnifiedDiff> unifiedDiffs = new ArrayList<>();
+		SubMonitor progress = SubMonitor.convert(monitor, CompareMessages.UnifiedDiff_computing, 100);
+		RangeDifference[] rangeDiffs = RangeDifferencer.findDifferences(progress.split(70), left, right);
+		// The token diff of every change is computed eagerly, so let the user out of it.
+		SubMonitor tokenProgress = progress.split(30).setWorkRemaining(rangeDiffs.length);
+		for (RangeDifference rangeDiff : rangeDiffs) {
+			tokenProgress.split(1);
+			try {
+				int leftStart = left.getTokenStart(rangeDiff.leftStart());
+				int leftEnd = getTokenEnd(left, rangeDiff.leftStart(), rangeDiff.leftLength());
+				String leftDiffSource = leftDocument.get(leftStart, leftEnd - leftStart);
+
+				int rightStart = right.getTokenStart(rangeDiff.rightStart());
+				int rightEnd = getTokenEnd(right, rangeDiff.rightStart(), rangeDiff.rightLength());
+				String rightDiffSource = rightDocument.get(rightStart, rightEnd - rightStart);
+
+				if (leftDiffSource.length() == 0 && rightDiffSource.length() == 0) {
+					continue;
+				}
+				boolean isWhitespace = false;
+				// Indicate whether all contributors are whitespace
+				if (ignoreWhiteSpace && leftDiffSource.trim().length() == 0 && rightDiffSource.trim().length() == 0) {
+					isWhitespace = true;
+
+					// Check if whitespace can be ignored by the contributor
+					if (leftDiffSource.length() > 0 && !lDocIgnonerWhitespaceContributor.isEmpty()) {
+						boolean isIgnored = lDocIgnonerWhitespaceContributor.get()
+								.isIgnoredWhitespace(rangeDiff.leftStart(), rangeDiff.leftLength());
+						isWhitespace = isIgnored;
+					}
+					if (isWhitespace && rightDiffSource.length() > 0 && !rDocIgnonreWhitespaceContributor.isEmpty()) {
+						boolean isIgnored = rDocIgnonreWhitespaceContributor.get()
+								.isIgnoredWhitespace(rangeDiff.rightStart(), rangeDiff.rightLength());
+						isWhitespace = isIgnored;
+					}
+				}
+				if (isWhitespace) {
+					continue;
+				}
+				int kind = rangeDiff.kind();
+				switch (kind) {
+				case RangeDifference.NOCHANGE:
+					break;
+				case RangeDifference.CHANGE:
+					var diff = new UnifiedDiff(leftDocument, leftStart, leftEnd, leftDiffSource, rightDocument,
+							rightStart, rightEnd, rightDiffSource, unifiedDiffs, mode);
+					unifiedDiffs.add(diff);
+
+					// line based fine granular diff via DocumentMerger#simpleTokenDiff
+					ITokenComparator l = createTokenComparator(leftDiffSource, tokenComparatorFactory);
+					ITokenComparator r = createTokenComparator(rightDiffSource, tokenComparatorFactory);
+					RangeDifference[] detailedDiffs = RangeDifferencer.findRanges((IRangeComparator) null, l, r);
+					for (RangeDifference detailedDiff : detailedDiffs) {
+						if (detailedDiff.kind() == RangeDifference.NOCHANGE) {
+							continue;
+						}
+						int detailedLeftStart = l.getTokenStart(detailedDiff.leftStart());
+						int detailedLeftEnd = getTokenEnd(l, detailedDiff.leftStart(), detailedDiff.leftLength());
+						String detailedLeftDiffSource = leftDiffSource.substring(detailedLeftStart, detailedLeftEnd);
+
+						int detailedRightStart = r.getTokenStart(detailedDiff.rightStart());
+						int detailedRightEnd = getTokenEnd(r, detailedDiff.rightStart(), detailedDiff.rightLength());
+						String detailedDiffRightDiffSource = rightDiffSource.substring(detailedRightStart,
+								detailedRightEnd);
+						if (detailedLeftDiffSource.trim().length() == 0
+								&& detailedDiffRightDiffSource.trim().length() == 0) {
+							continue;
+						}
+						diff.detailedDiffs.add(new UnifiedDiff(leftDocument, detailedLeftStart, detailedLeftEnd,
+								detailedLeftDiffSource, rightDocument, detailedRightStart, detailedRightEnd,
+								detailedDiffRightDiffSource, unifiedDiffs, mode));
+					}
+					break;
+				case RangeDifference.CONFLICT:
+					break;
+				case RangeDifference.LEFT:
+					break;
+				case RangeDifference.ERROR:
+					break;
+				case RangeDifference.ANCESTOR:
+					break;
+				default:
+					break;
+				}
+			} catch (BadLocationException e) {
+				error(e);
+			}
+		}
+		return unifiedDiffs;
 	}
 
 	public static void error(Exception e) {

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/AllCompareTests.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/AllCompareTests.java
@@ -36,6 +36,7 @@ import org.junit.platform.suite.api.Suite;
 	PatchLinesTest.class,
 	PatchUITest.class,
 	RangeDifferencerThreeWayDiffTest.class,
+	RangeDifferencerMonitorTest.class,
 	CompareUIPluginTest.class,
 	CompareOpenEfficiencyTest.class,
 	UnifiedDiffOpenTest.class,

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/RangeDifferencerMonitorTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/RangeDifferencerMonitorTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Lars Vogel and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eclipse contributors - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.compare.tests;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.eclipse.compare.internal.DocLineComparator;
+import org.eclipse.compare.rangedifferencer.RangeDifference;
+import org.eclipse.compare.rangedifferencer.IRangeComparator;
+import org.eclipse.compare.rangedifferencer.RangeDifferencer;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.jface.text.Document;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the two-way {@code findDifferences} honors the progress monitor
+ * it is given, so that a long running comparison can be canceled.
+ */
+public class RangeDifferencerMonitorTest {
+
+	private static final String S = System.lineSeparator();
+
+	@Test
+	public void testFindDifferencesIsCanceledByMonitor() {
+		IRangeComparator left = comparator("left"); //$NON-NLS-1$
+		IRangeComparator right = comparator("right"); //$NON-NLS-1$
+		NullProgressMonitor canceled = new NullProgressMonitor();
+		canceled.setCanceled(true);
+
+		try {
+			RangeDifferencer.findDifferences(canceled, left, right);
+			fail("a canceled monitor must abort the comparison"); //$NON-NLS-1$
+		} catch (OperationCanceledException expected) {
+			// the monitor is honored
+		}
+	}
+
+	@Test
+	public void testFindDifferencesCompletesWithoutCancellation() {
+		IRangeComparator left = comparator("left"); //$NON-NLS-1$
+		IRangeComparator right = comparator("right"); //$NON-NLS-1$
+
+		RangeDifference[] diffs = RangeDifferencer.findDifferences(new NullProgressMonitor(), left, right);
+
+		assertNotNull(diffs, "an uncanceled comparison must produce differences"); //$NON-NLS-1$
+	}
+
+	private static IRangeComparator comparator(String prefix) {
+		StringBuilder content = new StringBuilder();
+		for (int i = 0; i < 200; i++) {
+			content.append(prefix).append(' ').append(i).append(S);
+		}
+		return new DocLineComparator(new Document(content.toString()), null, false);
+	}
+}


### PR DESCRIPTION
Computing the unified diff ran uninterruptibly on the UI thread: the line diff over the whole file plus a nested token diff for every single change, with no progress and no way out, so a large file simply froze the editor. The computation now runs under the workbench progress service with a cancelable monitor, and the per change token diffs check for cancellation, so the busy cursor turns into a progress dialog when it takes long. Cancelling keeps the already opened text editor without annotations rather than falling back to the classic compare editor, since the user cancelled the diff and not the open.

While wiring that up I found that `RangeDifferencer.findDifferences(IProgressMonitor, left, right)` discarded the monitor it was handed and passed `null` on, so neither progress nor cancellation ever reached the LCS computation for two-way comparisons. The three-way overload right below it forwards the monitor correctly. `RangeDifferencerMonitorTest` covers the fix and fails without it.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/2795