### PR TITLE
Cache the syntax highlighting of a unified diff mining

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffCodeMiningProvider.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffCodeMiningProvider.java
@@ -363,6 +363,7 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 		private Rectangle lastRectangle;
 		private List<Rectangle> backgrounds;
 		private List<ForegroundInfo> foregrounds;
+		private List<StyleRange> styleRanges;
 		private Font cachedFont;
 		private final HashMap<Font, Map<Integer /* style */, Font>> styledFonts = new HashMap<>();
 
@@ -532,9 +533,22 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 			return this.diff;
 		}
 
+		/**
+		 * Highlighting depends on the document content only, so unlike the drawing
+		 * caches it survives a font change. Recomputing it means re-partitioning the
+		 * whole file prefix once per mining.
+		 */
+		private List<StyleRange> styleRanges(String label) {
+			if (styleRanges == null) {
+				styleRanges = computeStyleRanges(viewer, diff.leftStart, label);
+			}
+			return styleRanges;
+		}
+
 		@Override
 		public void dispose() {
 			cleanCachedData();
+			styleRanges = null;
 			super.dispose();
 		}
 
@@ -618,7 +632,7 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 			gc.fillRectangle(0, y, textWidget.getBounds().width /* result.x */, result.y);
 
 			String label = getLabel();
-			List<StyleRange> ranges = computeStyleRanges(viewer, diff.leftStart, label);
+			List<StyleRange> ranges = styleRanges(label);
 
 			// draw darker background for detailed diff
 			gc.setBackground(this.detailedDiffColor);


### PR DESCRIPTION
Every draw of a unified diff code mining whose drawing cache had been dropped recomputed the syntax highlighting of the overlaid text, and that is far from cheap: `SourceViewer.computeStyleRanges` reconnects the document partitioner to a temporary document holding the whole file prefix plus the diff text, and reconnects it to the real document afterwards, so each call re-partitions the file twice. With many changes in a large file, a single font change or editor zoom step made every visible mining pay that again.

The style ranges depend on the document content alone and not on the font, so they are now cached per mining and survive the font driven cache invalidation. They are dropped when the mining is disposed, and the mining itself is recreated whenever the document changes, so the cache cannot go stale. The ranges are never mutated in place either: the one place that needs a font clones the range first.

This is the drawing path, so it is not covered by a unit test; the existing unified diff tests still pass.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/2795