### PR TITLE
Show a large comparison before computing its differences

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -502,6 +502,18 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 	private boolean isConfigured = false;
 	private boolean fRedoDiff = false;
 
+	/**
+	 * Combined line count of both sides from which on the first comparison is
+	 * deferred, so that the documents are painted before they are compared. Smaller
+	 * inputs are compared right away: the diff costs next to nothing there, and
+	 * showing the text and jumping to the first change in two steps would only
+	 * flicker.
+	 */
+	private static final int DEFER_DIFF_LINE_COUNT = 2000;
+
+	/** Pending first diff of the current input, scheduled after the documents are set. */
+	private UIJob fInitialDiffJob;
+
 	private double fCurrMagni = 0;
 
 	private int fCurrentHeight;
@@ -2103,6 +2115,11 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 	protected void handleDispose(DisposeEvent event) {
 		OperationHistoryFactory.getOperationHistory().removeOperationHistoryListener(operationHistoryListener);
 
+		if (fInitialDiffJob != null) {
+			fInitialDiffJob.cancel();
+			fInitialDiffJob = null;
+		}
+
 		if (fHandlerService != null) {
 			fHandlerService.dispose();
 		}
@@ -3211,41 +3228,73 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 
 		setSyncScrolling(fPreferenceStore.getBoolean(ComparePreferencePage.SYNCHRONIZE_SCROLLING));
 
-		update(false);
-
-		if (!fHasErrors && !emptyInput && !fComposite.isDisposed()) {
-			if (isRefreshing()) {
-				fLeftContributor.updateSelection(fLeft, !fSynchronizedScrolling);
-				fRightContributor.updateSelection(fRight, !fSynchronizedScrolling);
-				fAncestorContributor.updateSelection(fAncestor, !fSynchronizedScrolling);
-				if (fSynchronizedScrolling && fSynchronziedScrollPosition != -1) {
-					synchronizedScrollVertical(fSynchronziedScrollPosition);
-				}
-			} else {
-				if (isPatchHunk()) {
-					if (right != null && Adapters.adapt(right, IHunk.class) != null) {
-						fLeft.getSourceViewer().setTopIndex(getHunkStart());
-					} else {
-						fRight.getSourceViewer().setTopIndex(getHunkStart());
+		// A refresh restores the cached selection and scroll position, and that cache is
+		// dropped as soon as the refresh returns, so a refresh is never deferred.
+		if (isRefreshing() || fLeftLineCount + fRightLineCount <= DEFER_DIFF_LINE_COUNT) {
+			update(false);
+			if (!fHasErrors && !emptyInput && !fComposite.isDisposed()) {
+				if (isRefreshing()) {
+					fLeftContributor.updateSelection(fLeft, !fSynchronizedScrolling);
+					fRightContributor.updateSelection(fRight, !fSynchronizedScrolling);
+					fAncestorContributor.updateSelection(fAncestor, !fSynchronizedScrolling);
+					if (fSynchronizedScrolling && fSynchronziedScrollPosition != -1) {
+						synchronizedScrollVertical(fSynchronziedScrollPosition);
 					}
 				} else {
-					Diff selectDiff= null;
-					if (FIX_47640) {
-						if (leftRange != null) {
-							selectDiff= fMerger.findDiff(LEFT_CONTRIBUTOR, leftRange);
-						} else if (rightRange != null) {
-							selectDiff= fMerger.findDiff(RIGHT_CONTRIBUTOR, rightRange);
-						}
-					}
-					if (selectDiff != null) {
-						setCurrentDiff(selectDiff, true);
-					} else {
-						selectFirstDiff(true);
-					}
+					revealInitialDiff(right, leftRange, rightRange);
 				}
 			}
+			return;
 		}
 
+		// The documents are set, so let them be painted before comparing them. The diff
+		// and everything derived from it follows in a separate UI event.
+		final boolean isEmptyInput = emptyInput;
+		final Object rightElement = right;
+		final Position leftSelectRange = leftRange;
+		final Position rightSelectRange = rightRange;
+		if (fInitialDiffJob != null) {
+			fInitialDiffJob.cancel();
+		}
+		fInitialDiffJob = new UIJob(CompareMessages.DocumentMerger_0) {
+			@Override
+			public IStatus runInUIThread(IProgressMonitor monitor) {
+				fInitialDiffJob = null;
+				if (fComposite == null || fComposite.isDisposed()) {
+					return Status.OK_STATUS;
+				}
+				update(false);
+				if (!fHasErrors && !isEmptyInput && !fComposite.isDisposed()) {
+					revealInitialDiff(rightElement, leftSelectRange, rightSelectRange);
+				}
+				return Status.OK_STATUS;
+			}
+		};
+		fInitialDiffJob.schedule();
+	}
+
+	private void revealInitialDiff(Object right, Position leftRange, Position rightRange) {
+		if (isPatchHunk()) {
+			if (right != null && Adapters.adapt(right, IHunk.class) != null) {
+				fLeft.getSourceViewer().setTopIndex(getHunkStart());
+			} else {
+				fRight.getSourceViewer().setTopIndex(getHunkStart());
+			}
+			return;
+		}
+		Diff selectDiff= null;
+		if (FIX_47640) {
+			if (leftRange != null) {
+				selectDiff= fMerger.findDiff(LEFT_CONTRIBUTOR, leftRange);
+			} else if (rightRange != null) {
+				selectDiff= fMerger.findDiff(RIGHT_CONTRIBUTOR, rightRange);
+			}
+		}
+		if (selectDiff != null) {
+			setCurrentDiff(selectDiff, true);
+		} else {
+			selectFirstDiff(true);
+		}
 	}
 
 	private void configureSourceViewer(SourceViewer sourceViewer, boolean editable, ContributorInfo contributor) {

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/TextMergeViewerTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/TextMergeViewerTest.java
@@ -459,6 +459,55 @@ public class TextMergeViewerTest  {
 		}
 	}
 
+	/**
+	 * A large input must be shown before it is compared, so the differences are only
+	 * available once the deferred comparison ran.
+	 */
+	@Test
+	public void testLargeInputIsShownBeforeItIsCompared() throws Exception {
+		DiffNode parentNode = new DiffNode(new ParentTestElement(), new ParentTestElement());
+		DiffNode testNode = new DiffNode(parentNode, Differencer.CHANGE, null,
+				new EditableTestElement(manyLines("line", 3000).getBytes()),
+				new EditableTestElement(manyLines("LINE", 3000).getBytes()));
+
+		runInDialog(testNode, () -> {
+			IMergeViewerTestAdapter ta = viewer.getAdapter(IMergeViewerTestAdapter.class);
+			assertEquals(0, ta.getChangesCount(), "a large input must not be compared before it is shown");
+			waitForChanges(ta);
+			assertTrue(ta.getChangesCount() > 0, "the deferred comparison did not produce differences");
+		});
+	}
+
+	private static String manyLines(String prefix, int count) {
+		StringBuilder content = new StringBuilder();
+		for (int i = 0; i < count; i++) {
+			content.append(prefix).append(' ').append(i).append('\n');
+		}
+		return content.toString();
+	}
+
+	private static void waitForChanges(IMergeViewerTestAdapter ta) {
+		Display display = Display.getCurrent();
+		long deadline = System.currentTimeMillis() + 30_000;
+		// A self-rescheduling timer keeps the loop waking so the deadline is enforced
+		// even while blocked in Display.sleep().
+		Runnable[] wake = new Runnable[1];
+		wake[0] = () -> display.timerExec(50, wake[0]);
+		display.timerExec(50, wake[0]);
+		try {
+			while (ta.getChangesCount() == 0) {
+				if (System.currentTimeMillis() > deadline) {
+					fail("no differences within 30000ms");
+				}
+				if (!display.readAndDispatch()) {
+					display.sleep();
+				}
+			}
+		} finally {
+			display.timerExec(-1, wake[0]);
+		}
+	}
+
 	@Test
 	public void testCompareFilter() throws Exception {
 		DiffNode parentNode = new DiffNode(new ParentTestElement(),


### PR DESCRIPTION
`TextMergeViewer` computed the line diff and the token diffs of every change before the documents were painted, so opening a compare editor left it blank for the whole comparison. Once both sides together exceed 2000 lines, the first comparison now runs in a follow-up UI event, exactly the way the re-diff after an edit already works, and the change highlighting plus the jump to the first difference follow when it is done. Time from `openCompareEditor` until the text is visible, medians over 15 repetitions on Linux with Xvfb: 237ms to 77ms for 5000 lines with 100 changes, 491ms to 96ms for 5000 lines with 1250 changes, and 427ms to 135ms for 50000 lines with 1000 changes.

Two cases stay synchronous on purpose. Smaller inputs are compared right away, because there the diff costs next to nothing and showing the text and then jumping to the first change would only flicker; that also keeps the existing contract for the many small comparisons that dominate in practice. A refresh is never deferred either, since it restores the cached selection and scroll position, and that cache is dropped as soon as the refresh returns.

`TextMergeViewerTest.testLargeInputIsShownBeforeItIsCompared` pins the new behaviour and fails without the change.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/2795