### PR TITLE
Make the compare editor font zoom shortcut work off macOS

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -3267,10 +3267,13 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		styleText.addKeyListener(new KeyAdapter() {
 			@Override
 			public void keyPressed(KeyEvent e) {
-				if ((e.stateMask & SWT.COMMAND) != 0 && (e.keyCode == '=' || e.keyCode == '+')) {
-					updateFontSize(true, LocalResManager);
+				// MOD1 is Command on macOS and Ctrl elsewhere
+				if ((e.stateMask & SWT.MOD1) == 0) {
+					return;
 				}
-				if ((e.stateMask & SWT.COMMAND) != 0 && e.keyCode == '-') {
+				if (e.keyCode == '=' || e.keyCode == '+' || e.keyCode == SWT.KEYPAD_ADD) {
+					updateFontSize(true, LocalResManager);
+				} else if (e.keyCode == '-' || e.keyCode == SWT.KEYPAD_SUBTRACT) {
 					updateFontSize(false, LocalResManager);
 				}
 			}
@@ -6161,7 +6164,12 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 		Font newFont = localResManager.create(desc);
 		leftStyle.setFont(newFont);
 		rightStyle.setFont(newFont);
-		doDiff();
+		if (fAncestor != null) {
+			fAncestor.getSourceViewer().getTextWidget().setFont(newFont);
+		}
+		// The differences do not depend on the font, only the line geometry does.
+		updateVScrollBar();
+		updatePresentation();
 	}
 
 }


### PR DESCRIPTION
The key listener that zooms the compare editor text checked `SWT.COMMAND`, a modifier that is only ever set on macOS, so Ctrl+= and Ctrl+- did nothing on Linux and Windows while the pinch gesture worked everywhere. It now checks `SWT.MOD1`, which resolves to Command on macOS and Ctrl elsewhere, and it accepts the keypad plus and minus keys as well.

Two things noticed in the same method: the ancestor pane kept its old font in a three-way compare, and every zoom step re-ran the whole comparison even though the differences do not depend on the font. Only the line geometry does, so the vertical scroll bar and the presentation are refreshed instead, which also makes zooming a large comparison responsive.

Contributes to https://github.com/eclipse-platform/eclipse.platform/issues/2795