### PR TITLE
Add Toggle to Sort LaunchConfigurations by most recent launch

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPreferenceInitializer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPreferenceInitializer.java
@@ -69,6 +69,7 @@ public class DebugUIPreferenceInitializer extends AbstractPreferenceInitializer 
 		prefs.setDefault(IInternalDebugUIConstants.PREF_USE_CONTEXTUAL_LAUNCH, true);
 		prefs.setDefault(IInternalDebugUIConstants.PREF_LAUNCH_PARENT_PROJECT, false);
 		prefs.setDefault(IInternalDebugUIConstants.PREF_LAUNCH_LAST_IF_NOT_LAUNCHABLE, true);
+		prefs.setDefault(IInternalDebugUIConstants.PREF_LAUNCHCONFIG_SORT_ON_RECENT, false);
 
 		prefs.setDefault(IInternalDebugUIConstants.PREF_TERMINATE_AND_RELAUNCH_LAUNCH_ACTION, false);
 		prefs.setDefault(IInternalDebugUIConstants.PREF_BREAKPOINT_SORTING_ORDER,

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/IInternalDebugUIConstants.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/IInternalDebugUIConstants.java
@@ -435,4 +435,10 @@ public interface IInternalDebugUIConstants {
 	 */
 	String EXPRESSION_PASTE_AS_MULTI = "org.eclipse.debug.ui.expression.paste.multi"; //$NON-NLS-1$
 
+	/**
+	 * String indicating sorting order of launch configurations in
+	 * LaunchConfigurations View
+	 */
+	String PREF_LAUNCHCONFIG_SORT_ON_RECENT = IDebugUIConstants.PLUGIN_ID + ".PREF_LAUNCHCONFIG_SORT_ON_RECENT"; //$NON-NLS-1$
+
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationComparator.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2015 IBM Corporation and others.
+ * Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -24,6 +24,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.internal.ui.DebugUIPlugin;
+import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.ui.model.WorkbenchViewerComparator;
 
 /**
@@ -37,6 +39,20 @@ public class LaunchConfigurationComparator extends WorkbenchViewerComparator {
 	 * the map of categories of <code>ILaunchConfigurationType</code>s to <code>Integer</code>s entries
 	 */
 	private static Map<ILaunchConfigurationType, Integer> fgCategories;
+	private final Map<ILaunchConfiguration, Integer> recentLaunches = new HashMap<>();
+
+	public LaunchConfigurationComparator(String groupIdentifier) {
+		LaunchHistory history = DebugUIPlugin.getDefault().getLaunchConfigurationManager().getLaunchHistory(groupIdentifier);
+		if (history != null) {
+			ILaunchConfiguration[] launches = history.getCompleteLaunchHistory();
+			for (int i = 0; i < launches.length; i++) {
+				recentLaunches.put(launches[i], Integer.valueOf(i));
+			}
+		}
+	}
+
+	public LaunchConfigurationComparator() {
+	}
 
 	/**
 	 * @see org.eclipse.jface.viewers.ViewerComparator#category(java.lang.Object)
@@ -54,6 +70,27 @@ public class LaunchConfigurationComparator extends WorkbenchViewerComparator {
 			}
 		}
 		return map.size();
+	}
+
+	@Override
+	public int compare(Viewer viewer, Object e1, Object e2) {
+		if (e1 instanceof ILaunchConfiguration c1 && e2 instanceof ILaunchConfiguration c2) {
+			Integer recent1 = recentLaunches.get(c1);
+			Integer recent2 = recentLaunches.get(c2);
+			if (recent1 != null || recent2 != null) {
+				if (recent1 == null) {
+					return 1;
+				}
+				if (recent2 == null) {
+					return -1;
+				}
+				int result = recent1.compareTo(recent2);
+				if (result != 0) {
+					return result;
+				}
+			}
+		}
+		return super.compare(viewer, e1, e2);
 	}
 
 	/**

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationFilteredTree.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationFilteredTree.java
@@ -21,6 +21,7 @@ import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.internal.core.IInternalDebugCoreConstants;
 import org.eclipse.debug.internal.ui.DebugUIPlugin;
 import org.eclipse.debug.internal.ui.IDebugHelpContextIds;
+import org.eclipse.debug.internal.ui.IInternalDebugUIConstants;
 import org.eclipse.debug.ui.DebugUITools;
 import org.eclipse.debug.ui.ILaunchGroup;
 import org.eclipse.help.HelpSystem;
@@ -76,8 +77,14 @@ public final class LaunchConfigurationFilteredTree extends FilteredTree {
 	@Override
 	protected TreeViewer doCreateTreeViewer(Composite cparent, int style) {
 		treeViewer = new LaunchConfigurationViewer(cparent, style);
-		treeViewer.setLabelProvider(new DecoratingLabelProvider(DebugUITools.newDebugModelPresentation(), PlatformUI.getWorkbench().getDecoratorManager().getLabelDecorator()));
-		treeViewer.setComparator(new WorkbenchViewerComparator());
+
+		treeViewer.setLabelProvider(new DecoratingLabelProvider(DebugUITools.newDebugModelPresentation(),
+				PlatformUI.getWorkbench().getDecoratorManager().getLabelDecorator()));
+		boolean sortByRecent = DebugUIPlugin.getDefault().getPreferenceStore()
+				.getBoolean(IInternalDebugUIConstants.PREF_LAUNCHCONFIG_SORT_ON_RECENT);
+
+		treeViewer.setComparator(sortByRecent ? new LaunchConfigurationComparator(fLaunchGroup.getIdentifier())
+				: new WorkbenchViewerComparator());
 		treeViewer.setContentProvider(new LaunchConfigurationTreeContentProvider(fLaunchGroup.getMode(), cparent.getShell()));
 		treeViewer.addFilter(new LaunchGroupFilter(fLaunchGroup));
 		treeViewer.setUseHashlookup(true);
@@ -223,6 +230,10 @@ public final class LaunchConfigurationFilteredTree extends FilteredTree {
 		super.updateToolbar(visible);
 		// update filter count
 		getLaunchConfigurationViewer().filterChanged();
+	}
+
+	public ILaunchGroup getLaunchGroup() {
+		return fLaunchGroup;
 	}
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationView.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationView.java
@@ -96,6 +96,8 @@ public class LaunchConfigurationView extends AbstractDebugView implements ILaunc
 	 */
 	private FilterLaunchConfigurationAction fFilterAction;
 
+	private SortLaunchConfigurationAction fSort;
+
 	/**
 	 * This label is used to notify users that items (possibly) have been filtered from the
 	 * launch configuration view
@@ -225,6 +227,9 @@ public class LaunchConfigurationView extends AbstractDebugView implements ILaunc
 		fFilterAction = new FilterLaunchConfigurationAction();
 		setAction(FilterLaunchConfigurationAction.ID_FILTER_ACTION, fFilterAction);
 
+		fSort = new SortLaunchConfigurationAction(fTree);
+		setAction(SortLaunchConfigurationAction.ID_SORT_ACTION, fSort);
+
 		fLinkPrototypeAction = new LinkPrototypeAction(getViewer(), getLaunchGroup().getMode());
 		setAction(LinkPrototypeAction.ID_LINK_PROTOTYPE_ACTION, fLinkPrototypeAction);
 
@@ -291,6 +296,7 @@ public class LaunchConfigurationView extends AbstractDebugView implements ILaunc
 		fExportAction.dispose();
 		fImportAction.dispose();
 		fFilterAction = null;
+		fSort = null;
 		fCollapseAllAction = null;
 		fLinkPrototypeAction.dispose();
 		fUnlinkPrototypeAction.dispose();

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsDialog.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsDialog.java
@@ -510,6 +510,7 @@ public class LaunchConfigurationsDialog extends TitleAreaDialog implements ILaun
 		tmanager.add(new Separator());
 		tmanager.add(getCollapseAllAction());
 		tmanager.add(getFilterAction());
+		tmanager.add(getSortAction());
 		tmanager.update(true);
 		DebugUIPlugin.getDefault().getPreferenceStore().addPropertyChangeListener(this);
 	}
@@ -721,6 +722,10 @@ public class LaunchConfigurationsDialog extends TitleAreaDialog implements ILaun
 	 */
 	protected IAction getFilterAction() {
 		return fLaunchConfigurationView.getAction(FilterLaunchConfigurationAction.ID_FILTER_ACTION);
+	}
+
+	protected IAction getSortAction() {
+		return fLaunchConfigurationView.getAction(SortLaunchConfigurationAction.ID_SORT_ACTION);
 	}
 
 	/**

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.java
@@ -318,11 +318,14 @@ public class LaunchConfigurationsMessages extends NLS {
 	public static String QuickGroupLaunchActionLabel;
 
 	public static String QuickGroupLaunchActionToolTip;
-
 	public static String FavoritesDialogPromptOnClose;
 
 	public static String FavoritesDialogPromptOnCloseTitle;
 
 	public static String FavoritesDialogPromptOnCloseSaveButton;
+
+	public static String SortLaunchConfigurationAction;
+
+	public static String SortLaunchConfigurationActionDesc;
 
 }

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.properties
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationsMessages.properties
@@ -293,3 +293,5 @@ SelectLaunchersDialog_4=<a href="ws">Change Workspace Settings...</a>
 SelectLaunchersDialog_5=Description
 SelectLaunchersDialog_launchers=Launc&hers:
 SelectFavTypeToFilter= Type to filter
+SortLaunchConfigurationAction=Sort launch configurations
+SortLaunchConfigurationActionDesc=Sort launch configurations by recent launch

--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/SortLaunchConfigurationAction.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/SortLaunchConfigurationAction.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.debug.internal.ui.launchConfigurations;
+
+import org.eclipse.debug.internal.ui.DebugUIPlugin;
+import org.eclipse.debug.internal.ui.IInternalDebugUIConstants;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.debug.ui.IDebugUIConstants;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.ui.model.WorkbenchViewerComparator;
+
+/**
+ * provides the implementation for sorting the launch configurations within the
+ * Launch Configuration Dialog
+ */
+public class SortLaunchConfigurationAction extends Action {
+
+	/**
+	 * Action identifier for IDebugView#getAction(String)
+	 */
+	public static final String ID_SORT_ACTION = DebugUIPlugin.getUniqueIdentifier() + ".ID_SORT_ACTION"; //$NON-NLS-1$
+
+	private LaunchConfigurationFilteredTree fTree;
+
+	public SortLaunchConfigurationAction(LaunchConfigurationFilteredTree tree) {
+		super(LaunchConfigurationsMessages.SortLaunchConfigurationAction, IAction.AS_CHECK_BOX);
+		fTree = tree;
+		setChecked(DebugUIPlugin.getDefault().getPreferenceStore()
+				.getBoolean(IInternalDebugUIConstants.PREF_LAUNCHCONFIG_SORT_ON_RECENT));
+	}
+
+	@Override
+	public void run() {
+		TreeViewer viewer = fTree.getViewer();
+		IPreferenceStore prefStore = DebugUIPlugin.getDefault().getPreferenceStore();
+		boolean isSortByRecent = prefStore.getBoolean(IInternalDebugUIConstants.PREF_LAUNCHCONFIG_SORT_ON_RECENT);
+		viewer.setComparator(isSortByRecent ? new WorkbenchViewerComparator()
+				: new LaunchConfigurationComparator(fTree.getLaunchGroup().getIdentifier()));
+		prefStore.setValue(IInternalDebugUIConstants.PREF_LAUNCHCONFIG_SORT_ON_RECENT, !isSortByRecent);
+		viewer.refresh();
+	}
+
+	@Override
+	public String getDescription() {
+		return LaunchConfigurationsMessages.SortLaunchConfigurationActionDesc;
+	}
+
+	@Override
+	public ImageDescriptor getImageDescriptor() {
+		return DebugUITools.getImageDescriptor(IDebugUIConstants.IMG_LCL_DETAIL_PANE_HIDE);
+	}
+
+	@Override
+	public String getToolTipText() {
+		return LaunchConfigurationsMessages.SortLaunchConfigurationActionDesc;
+	}
+}


### PR DESCRIPTION
Adds a check-box toolbar action to the Launch Configurations dialog that toggles the tree sort order between alphabetical-by-type (the existing default) and most-recently-launched within each type group. 

<img width="475" height="88" alt="Screenshot 2026-07-30 at 6 27 45 PM" src="https://github.com/user-attachments/assets/f12d1bd7-407e-45f6-a139-43036963cf87" />

When launch configurations share similar names or there are many of them, finding the one you recently ran to re-launch it or tweak its parameters means scanning an alphabetical list every time. This toggle re-sorts the tree so your most recently used configurations rise to the top of each type group, making them faster to find. The number of configurations considered "recent" is governed by the existing "_Size of recently launched applications list:_" preference, so users who increase that limit will see a broader recency-based sort order.



https://github.com/user-attachments/assets/3838f530-49d9-45c2-9b5b-e17c2090f0c1

