### PR TITLE
Fall back to the compare editor when no unified diff can be shown

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -700,7 +700,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 					.open();
 			// The user canceled the diff, not the open: leave the text editor alone
 			// instead of falling back to the classic compare editor.
-			return status.isOK() || status.getCode() == UnifiedDiffManager.CANCELED_BY_USER_CODE;
+			return status.isOK() || status == UnifiedDiffManager.CANCELED_BY_USER;
 		} catch (PartInitException e) {
 			CompareUIPlugin.log(e);
 		}

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffManager.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffManager.java
@@ -113,15 +113,14 @@ public class UnifiedDiffManager {
 	private static final String TOOLBAR_COMPOSITE_FOR_ALL_DIFFS_KEY = "TOOLBAR_COMPOSITE_FOR_ALL_DIFFS_KEY"; //$NON-NLS-1$
 	private static final Map<ITextViewer, List<UnifiedDiff>> diffsByViewer = new HashMap<>();
 
-	/** Status code reported when the user canceled the diff computation. */
-	public static final int CANCELED_BY_USER_CODE = 1;
-
 	/**
 	 * The user canceled the computation. The text editor is already open, so the
-	 * caller must not fall back to the classic compare editor.
+	 * caller must not fall back to the classic compare editor. Compared by identity,
+	 * because a status code would clash with {@link Status#CANCEL_STATUS}, which
+	 * this class returns when it cannot show a unified diff at all.
 	 */
-	private static final IStatus CANCELED_BY_USER = new Status(IStatus.CANCEL, UnifiedDiffManager.class,
-			CANCELED_BY_USER_CODE, "canceled by the user", null); //$NON-NLS-1$
+	public static final IStatus CANCELED_BY_USER = new Status(IStatus.CANCEL, UnifiedDiffManager.class,
+			"canceled by the user"); //$NON-NLS-1$
 
 	public static void put(ITextViewer viewer, List<UnifiedDiff> diffs) {
 		diffsByViewer.put(viewer, diffs);

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/UnifiedDiffOpenTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/UnifiedDiffOpenTest.java
@@ -16,7 +16,9 @@ package org.eclipse.compare.tests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -38,6 +40,7 @@ import org.eclipse.compare.SharedDocumentAdapter;
 import org.eclipse.compare.internal.CompareEditor;
 import org.eclipse.compare.internal.ComparePreferencePage;
 import org.eclipse.compare.internal.CompareUIPlugin;
+import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager;
 import org.eclipse.compare.structuremergeviewer.DiffNode;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -46,6 +49,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.Annotation;
@@ -255,6 +259,20 @@ public class UnifiedDiffOpenTest {
 		assertTrue(input.prepareInputCount.get() >= 1, "prepareInput did not run"); //$NON-NLS-1$
 		assertEquals(false, input.anyRunOnUiThread,
 				"the unified diff path must prepare the input off the UI thread"); //$NON-NLS-1$
+	}
+
+	/**
+	 * The marker the unified diff uses to say "the user canceled, keep the editor"
+	 * must be distinguishable from the plain cancel status it returns when it cannot
+	 * show a diff at all, otherwise the fallback to the compare editor is skipped
+	 * and the user is left with a text editor showing nothing.
+	 */
+	@Test
+	public void testUserCancelMarkerIsNotAPlainCancelStatus() {
+		assertNotSame(Status.CANCEL_STATUS, UnifiedDiffManager.CANCELED_BY_USER,
+				"the user cancel marker must be its own status"); //$NON-NLS-1$
+		assertNotEquals(Status.CANCEL_STATUS.getCode(), UnifiedDiffManager.CANCELED_BY_USER.getCode(),
+				"the user cancel marker must not share the code of Status.CANCEL_STATUS"); //$NON-NLS-1$
 	}
 
 	@Test


### PR DESCRIPTION
The marker status introduced in 4a9fc3f1d7 to say "the user canceled the computation, keep the text editor open" used status code 1, which is exactly the code of `Status.CANCEL_STATUS`. `UnifiedDiffManager.open` returns that plain cancel status when it cannot show a unified diff at all, namely when the editor has no annotation model and when `validateEdit` fails. Both were then mistaken for a user cancellation, so the fallback to the classic compare editor was skipped and the user was left looking at a plain text editor with no comparison in it.

The marker is now its own status object, compared by identity, so it cannot collide with any other cancel status. A test pins that it stays distinguishable from `Status.CANCEL_STATUS`.

Regression from 4a9fc3f1d7, reported after it was merged.