### PR TITLE
Keep the unified diff on the side that is a workspace file

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -824,14 +824,18 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 				|| !(right instanceof IStreamContentAccessor rightSource)) {
 			return null;
 		}
-		// The side that is not shown in the editor supplies the diff source, so it is
-		// read here instead of on the UI thread.
+		// The overlay needs a workspace file to sit on; an editor opened on anything
+		// else, a revision for example, comes up empty. The other side supplies the
+		// diff source and is read here rather than on the UI thread.
 		if (leftEditorInput instanceof IFileEditorInput) {
 			return new UnifiedDiffSource(compareInput, leftEditorInput, left, UnifiedDiffMode.REVERT_MODE,
 					getSourceOf(rightSource));
 		}
-		return new UnifiedDiffSource(compareInput, rightEditorInput, right, UnifiedDiffMode.OVERLAY_READ_ONLY_MODE,
-				getSourceOf(leftSource));
+		if (rightEditorInput instanceof IFileEditorInput) {
+			return new UnifiedDiffSource(compareInput, rightEditorInput, right, UnifiedDiffMode.OVERLAY_READ_ONLY_MODE,
+					getSourceOf(leftSource));
+		}
+		return null;
 	}
 
 	private static IEditorInput documentKeyOf(ITypedElement element) {


### PR DESCRIPTION
The unified diff is overlaid onto an editor, and it picks the side it opens: the left one when that is a workspace file, otherwise the right one. For a file that only lives in the git working tree and is not part of any imported project, neither side is a workspace file, so the else branch opened an editor on the revision. That editor comes up empty, no diff can be applied to it, and the classic compare editor then opens on top of it, so the user ends up with an empty editor next to the comparison, even though the unified diff preference is on. The same file inside a project works, because then the left side is a workspace file.

Only a side that is a workspace file is used now. When neither side is one, the unified diff steps aside and the classic compare editor opens on its own, without a stray empty editor.

This narrows the unified diff to comparisons that involve a workspace file. Supporting external files is possible in principle, since Eclipse opens those in a text editor as well, but it means choosing the side by editability rather than by workspace membership; that is a separate change.

Reported for a markdown file that only appeared through the Git Staging view.