### PR TITLE
Allow disabling automatic reconstruction of terminals #2563

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.control/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.control/META-INF/MANIFEST.MF
@@ -25,10 +25,10 @@ Export-Package: org.eclipse.terminal.connector;version="1.0.100";
    org.eclipse.terminal.connector,
    org.eclipse.terminal.model",
  org.eclipse.terminal.internal.connector;x-internal:=true,
- org.eclipse.terminal.internal.control.impl;x-internal:=true,
+ org.eclipse.terminal.internal.control.impl;x-internal:=true;x-friends:="org.eclipse.terminal.view.ui",
  org.eclipse.terminal.internal.emulator;x-internal:=true,
  org.eclipse.terminal.internal.model;x-internal:=true,
- org.eclipse.terminal.internal.preferences;x-internal:=true,
+ org.eclipse.terminal.internal.preferences;x-internal:=true;x-friends:="org.eclipse.terminal.view.ui",
  org.eclipse.terminal.internal.textcanvas;x-internal:=true,
  org.eclipse.terminal.model;version="1.0.100";uses:="org.eclipse.swt.graphics"
 Automatic-Module-Name: org.eclipse.terminal.control

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/control/impl/TerminalMessages.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/control/impl/TerminalMessages.java
@@ -56,6 +56,7 @@ public class TerminalMessages extends NLS {
 
 	//Preference Page
 	public static String INVERT_COLORS;
+	public static String RESTORE_TERMINALS;
 	public static String BUFFERLINES;
 
 }

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/control/impl/TerminalMessages.properties
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/control/impl/TerminalMessages.properties
@@ -55,4 +55,5 @@ CannotConnectTo = Cannot initialize {0}:\n{1}
 NotInitialized = Not Initialized
 
 INVERT_COLORS = Invert terminal colors
+RESTORE_TERMINALS = Reopen terminals after restart
 BUFFERLINES = Terminal buffer lines:

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/preferences/ITerminalConstants.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/preferences/ITerminalConstants.java
@@ -29,12 +29,14 @@ public interface ITerminalConstants {
 
 	public static final String PREF_BUFFERLINES = "TerminalPrefBufferLines"; //$NON-NLS-1$
 	public static final String PREF_INVERT_COLORS = "TerminalPrefInvertColors"; //$NON-NLS-1$
+	public static final String PREF_RESTORE_TERMINALS = "TerminalPrefRestoreTerminals"; //$NON-NLS-1$
 	/**
 	 * @since 5.0
 	 */
 	public static final String PREF_FONT_DEFINITION = "TerminalFontDefinition"; //$NON-NLS-1$
 	public static final int DEFAULT_BUFFERLINES = 1000;
 	public static final boolean DEFAULT_INVERT_COLORS = false;
+	public static final boolean DEFAULT_PREF_RESTORE_TERMINALS = true;
 	/**
 	 * @since 5.0
 	 */

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/preferences/TerminalPreferenceInitializer.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/preferences/TerminalPreferenceInitializer.java
@@ -41,6 +41,7 @@ public class TerminalPreferenceInitializer extends AbstractPreferenceInitializer
 		IEclipsePreferences defaultPrefs = DefaultScope.INSTANCE.getNode(TerminalPlugin.PLUGIN_ID);
 		defaultPrefs.putBoolean(ITerminalConstants.PREF_INVERT_COLORS, ITerminalConstants.DEFAULT_INVERT_COLORS);
 		defaultPrefs.putInt(ITerminalConstants.PREF_BUFFERLINES, ITerminalConstants.DEFAULT_BUFFERLINES);
+		defaultPrefs.putBoolean(ITerminalConstants.PREF_RESTORE_TERMINALS, ITerminalConstants.DEFAULT_PREF_RESTORE_TERMINALS);
 		defaultPrefs.put(ITerminalConstants.PREF_FONT_DEFINITION, ITerminalConstants.DEFAULT_FONT_DEFINITION);
 
 		Preset defaultPresets = TerminalColorPresets.INSTANCE.getDefaultPreset();

--- a/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/preferences/TerminalPreferencePage.java
+++ b/terminal/bundles/org.eclipse.terminal.control/src/org/eclipse/terminal/internal/preferences/TerminalPreferencePage.java
@@ -68,6 +68,8 @@ public class TerminalPreferencePage extends FieldEditorPreferencePage implements
 	}
 
 	protected void setupEditors() {
+		addField(new BooleanFieldEditor(ITerminalConstants.PREF_RESTORE_TERMINALS, TerminalMessages.RESTORE_TERMINALS,
+				getFieldEditorParent()));
 		addField(new BooleanFieldEditor(ITerminalConstants.PREF_INVERT_COLORS, TerminalMessages.INVERT_COLORS,
 				getFieldEditorParent()));
 
@@ -76,6 +78,7 @@ public class TerminalPreferencePage extends FieldEditorPreferencePage implements
 
 		terminalColorsFieldEditor = new TerminalColorsFieldEditor(getFieldEditorParent());
 		addField(terminalColorsFieldEditor);
+
 	}
 
 	@Override

--- a/terminal/bundles/org.eclipse.terminal.view.ui/META-INF/MANIFEST.MF
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.core.expressions;bundle-version="[3.9.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.22.0,4.0.0)";resolution:=optional,
  org.eclipse.ui.editors;bundle-version="[3.20.0,4.0.0)";resolution:=optional,
  org.eclipse.text;bundle-version="[3.14.0,4.0.0)";resolution:=optional,
- org.eclipse.terminal.view.core;bundle-version="[1.0.0,2.0.0)"
+ org.eclipse.terminal.view.core;bundle-version="[1.0.0,2.0.0)",
+ org.eclipse.terminal.control;bundle-version="[1.0.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/view/TerminalsView.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/view/TerminalsView.java
@@ -27,6 +27,7 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -53,6 +54,8 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.terminal.internal.control.impl.TerminalPlugin;
+import org.eclipse.terminal.internal.preferences.ITerminalConstants;
 import org.eclipse.terminal.view.ui.ITerminalsView;
 import org.eclipse.terminal.view.ui.internal.Messages;
 import org.eclipse.terminal.view.ui.internal.tabs.TabFolderManager;
@@ -90,6 +93,9 @@ public class TerminalsView extends ViewPart implements ITerminalsView, IShowInTa
 	private Control emptyPageControl;
 	// The view's memento handler
 	private final TerminalsViewMementoHandler mementoHandler = new TerminalsViewMementoHandler();
+
+	@SuppressWarnings("restriction")
+	private IPreferenceStore preferenceStore = TerminalPlugin.getDefault().getPreferenceStore();
 
 	/**
 	 * "dummy" transfer just to store the information needed for the DnD
@@ -706,8 +712,9 @@ public class TerminalsView extends ViewPart implements ITerminalsView, IShowInTa
 	 *
 	 * @param memento The memento or <code>null</code>.
 	 */
+	@SuppressWarnings("restriction")
 	public void restoreState(IMemento memento) {
-		if (memento == null) {
+		if (memento == null || !preferenceStore.getBoolean(ITerminalConstants.PREF_RESTORE_TERMINALS)) {
 			return;
 		}
 		mementoHandler.restoreState(this, memento);


### PR DESCRIPTION
## Summary
This PR adds a preference to disable automatically restoring the open terminals in the terminal view.

## Demonstration steps:
- Open Eclipse
- Open a terminal view with multiple terminals
- Close Eclipse while the terminal view is open
- Open Eclipse again
- After navigating to the terminal view, all terminals are restored.

This PR adds a new preference in Window > Preferences > Terminal named `Reopen terminals after restart` which is checked by default. If unchecked, no terminals will be restored.

<img width="866" height="690" alt="image" src="https://github.com/user-attachments/assets/a75dc62e-0fec-45d7-b2a0-141d0dd1bcd4" />

## Notes

- The terminal preference screen is located in `org.eclipse.terminal.control` while the related logic is present in `org.eclipse.terminal.view.ui`. I don't know what the best way to expose these classes is as they are `x-internal`. For now, I added an `x-friends` (mainly for documentation) and marked the access with `@SuppressWarnings("restriction")`.
- If you want to have a working terminal from a local "Eclipse Application" run configuration, you might need to add the `org.eclipse.cdt.core.native` and `org.eclipse.cdt.core.<your OS/arch>` bundles. I got them from the update site `https://download.eclipse.org/releases/2026-09`. This PR can still be tested without that but local terminals might just be empty rectangles without those.  
  <img width="669" height="376" alt="image" src="https://github.com/user-attachments/assets/6453fac1-fe1d-4e8e-8785-6344817b27cf" />
  <img width="981" height="301" alt="image" src="https://github.com/user-attachments/assets/144e0ca6-78b4-4990-b655-5a12908a257f" />
- I assume a small preference addition like this doesn't need a N&N? If one is wanted, I can also create that.

## Issues

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/2563