### PR TITLE
restore current working directory in terminal even if directory selected

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/launcher/LocalLauncherDelegate.java
+++ b/terminal/bundles/org.eclipse.terminal.connector.local/src/org/eclipse/terminal/connector/local/launcher/LocalLauncherDelegate.java
@@ -105,8 +105,10 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 			properties.put(ITerminalsConnectorConstants.PROP_FORCE_NEW, Boolean.TRUE);
 		}
 
+		boolean hadWorkingDirectoryBefore = properties
+				.containsKey(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR);
 		// Initialize the local terminal working directory.
-		if (!properties.containsKey(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR)) {
+		if (!hadWorkingDirectoryBefore) {
 			// By default, start the local terminal in the users home directory
 			String initialCwd = IPreferenceKeys.getPreferences()
 					.getString(IPreferenceKeys.PREF_LOCAL_TERMINAL_INITIAL_CWD);
@@ -213,7 +215,7 @@ public class LocalLauncherDelegate extends AbstractLauncherDelegate {
 						}
 					}
 				}
-				if (dir != null) {
+				if (!hadWorkingDirectoryBefore && dir != null) {
 					properties.put(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR, dir);
 
 					String basename = new Path(dir).lastSegment();

--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/TerminalService.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/TerminalService.java
@@ -14,9 +14,11 @@ package org.eclipse.terminal.view.ui.internal;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
@@ -250,6 +252,7 @@ public class TerminalService implements ITerminalService {
 	public CompletableFuture<?> openConsole(final Map<String, Object> properties) {
 		Assert.isNotNull(properties);
 		final boolean restoringView = fRestoringView;
+		AtomicReference<CompletableFuture<?>> endOperation = new AtomicReference<>(null);
 		return executeServiceOperation(properties, new TerminalServiceRunnable() {
 			@Override
 			public void run(TerminalViewId tvid, String title, ITerminalConnector connector, Object data)
@@ -261,7 +264,14 @@ public class TerminalService implements ITerminalService {
 					fRestoringView = true;
 					consoleViewManager.showConsoleView(tvid);
 					fRestoringView = false;
-					doRun(tvid, title, connector, data);
+
+					// To make sure that the terminals started by showConsoleView() are started first,
+					// we have to delay starting the current one with executeServiceOperation()
+					// (add the operation at the end of the queue)
+					endOperation.set(executeServiceOperation(
+							(tvid2, title2, connector2, data2) -> doRun(tvid, title, connector, data), tvid, title,
+							connector, data));
+
 				}
 			}
 
@@ -294,7 +304,8 @@ public class TerminalService implements ITerminalService {
 					console.setData("properties", properties); //$NON-NLS-1$
 				}
 			}
-		});
+		}).thenCompose(o -> Objects.<CompletableFuture<?>>requireNonNullElse(endOperation.get(),
+				CompletableFuture.completedFuture(o)));
 	}
 
 	@Override


### PR DESCRIPTION
When creating a new terminal with a folder selected (by pressing Ctrl+Alt+T) with terminals to be restored (i.e. #2850 is enabled and there are terminals from a previous session), Eclipse currently resets the working directory of the folders to be restored to the selection (and the new terminal is also using that selection).

This PR changes this by only using the selection for new terminals. As the new terminal was previously added at the beginning of the `CTabFolder`/list of terminals (because the order of the terminals being opened was wrong), I also made sure that the newly opened terminal is at the very right where it should be.

I hope nobody [relies on this broken behaviour](https://xkcd.com/1172/) (otherwise I could add a preference for the first fix but I don't really see why anyone would want that).

### How to test

- Start Eclipse
- Open one or more terminals in arbitrary directories
- Navigate to another view such that the terminal view is no longer visible
- Restart Eclipse
- Without opening the terminal view manually, open a terminal using a selected folder (`Show In` > `Local Terminal` or similar)
- The new terminal with the new directory should be opened at the end. The old terminals should "keep" their working directories from before the restart.




