### PR TITLE
Wait for the deferred zoom font disposal in ConsoleTests

### DIFF
--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleTests.java
@@ -469,13 +469,12 @@ public class ConsoleTests {
 			assertFalse(zoomFont.isDisposed(), "the zoom font must not be disposed while its console is still open");
 
 			removeConsoles(console);
-			TestUtil.processUIEvents(200);
-			long startTime = System.currentTimeMillis();
-			while (getConsoleManager().getConsoles().length > 0 && System.currentTimeMillis() - startTime < 60_000) {
-				TestUtil.processUIEvents(200);
-			}
-			assertEquals(0, getConsoleManager().getConsoles().length, "Should have no consoles after removal, but some are still present: " + Arrays.toString(getConsoleManager().getConsoles()));
-			assertTrue(zoomFont.isDisposed(), "the zoom font must be disposed once its console is removed");
+			TestUtil.waitWhile(() -> getConsoleManager().getConsoles().length > 0, 60_000,
+					() -> "Should have no consoles after removal, but some are still present: "
+							+ Arrays.toString(getConsoleManager().getConsoles()));
+			// the zoom fonts are disposed a UI cycle later, see ConsoleZoomHandler
+			TestUtil.waitWhile(() -> !zoomFont.isDisposed(), 10_000,
+					() -> "the zoom font must be disposed once its console is removed");
 		} finally {
 			removeConsoles(console);
 			hideConsoleView(consoleView);


### PR DESCRIPTION
`ConsoleZoomHandler` disposes the custom zoom fonts of a removed console one UI cycle later via `timerExec`, but `testRemovingConsoleDisposesZoomFont` asserted the disposal immediately after the console list had drained. When the console list emptied quickly and nothing pumped the display afterwards, the assertion ran before the timer fired, so the test failed sporadically on the macOS CI runners.

The test now polls for both conditions with `TestUtil.waitWhile` instead of a single immediate assertion, which also replaces the hand-rolled wait loop. Locally all 16 `ConsoleTests` pass.