### PR TITLE
Keep the unified diff scrollable when a file is emptied

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffCodeMiningProvider.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/unifieddiff/internal/UnifiedDiffCodeMiningProvider.java
@@ -229,15 +229,7 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 					continue;
 				}
 				try {
-					ICodeMining mining;
-					if (diff.leftStart == doc.getLength()) {
-						mining = new UnifiedDiffFooterCodeMining(doc, this, null, diff, tabWidth,
-								this.deletionBackgroundColor);
-					} else {
-						mining = new UnifiedDiffLineHeaderCodeMining(new Position(diff.leftStart, 1), this, diff,
-								tabWidth, this.detailedDiffColor, this.deletionBackgroundColor, tv);
-					}
-					minings.add(mining);
+					minings.add(createMining(doc, diff, diff.leftStart, tabWidth, tv));
 				} catch (BadLocationException e) {
 					error(e);
 				}
@@ -247,15 +239,7 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 					continue;
 				}
 				try {
-					ICodeMining mining;
-					if (diff.leftStart == doc.getLength()) {
-						mining = new UnifiedDiffFooterCodeMining(doc, this, null, diff, tabWidth,
-								this.deletionBackgroundColor);
-					} else {
-						mining = new UnifiedDiffLineHeaderCodeMining(new Position(diff.leftStart + diff.leftLength, 1),
-								this, diff, tabWidth, this.detailedDiffColor, this.deletionBackgroundColor, tv);
-					}
-					minings.add(mining);
+					minings.add(createMining(doc, diff, diff.leftStart + diff.leftLength, tabWidth, tv));
 				} catch (BadLocationException e) {
 					error(e);
 				}
@@ -264,20 +248,35 @@ public class UnifiedDiffCodeMiningProvider extends AbstractCodeMiningProvider {
 					continue;
 				}
 				try {
-					ICodeMining mining;
-					if (diff.leftStart == doc.getLength()) {
-						mining = new UnifiedDiffFooterCodeMining(doc, this, null, diff, tabWidth,
-								this.deletionBackgroundColor);
-					} else {
-						mining = new UnifiedDiffLineHeaderCodeMining(new Position(diff.leftStart, 1), this, diff,
-								tabWidth, this.detailedDiffColor, this.deletionBackgroundColor, tv);
-					}
-					minings.add(mining);
+					minings.add(createMining(doc, diff, diff.leftStart, tabWidth, tv));
 				} catch (BadLocationException e) {
 					error(e);
 				}
 			}
 		}
+	}
+
+	/**
+	 * A line header mining reserves its height as the vertical indent of its line,
+	 * so the viewer can scroll over it. A footer mining reserves nothing and is
+	 * therefore only used where no line start is available: behind the last,
+	 * non-empty line of the document.
+	 */
+	private ICodeMining createMining(IDocument doc, UnifiedDiff diff, int offset, int tabWidth, ITextViewer tv)
+			throws BadLocationException {
+		int end = doc.getLength();
+		if (offset >= end && !startsLine(doc, end)) {
+			return new UnifiedDiffFooterCodeMining(doc, this, null, diff, tabWidth, this.deletionBackgroundColor);
+		}
+		// a position must not reach beyond the document, otherwise the annotation model
+		// silently drops it
+		int start = Math.min(offset, end);
+		return new UnifiedDiffLineHeaderCodeMining(new Position(start, start < end ? 1 : 0), this, diff, tabWidth,
+				this.detailedDiffColor, this.deletionBackgroundColor, tv);
+	}
+
+	private static boolean startsLine(IDocument doc, int offset) throws BadLocationException {
+		return doc.getLineOffset(doc.getLineOfOffset(offset)) == offset;
 	}
 
 	static class UnifiedDiffFooterCodeMining extends DocumentFooterCodeMining {

--- a/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/UnifiedDiffManagerTest.java
+++ b/team/tests/org.eclipse.team.tests.core/src/org/eclipse/team/tests/ui/UnifiedDiffManagerTest.java
@@ -323,6 +323,25 @@ public class UnifiedDiffManagerTest {
 	}
 
 	/**
+	 * A diff at the very end of the document is shown as a code mining. Only a line
+	 * header mining reserves its height in the text widget, so an emptied file must
+	 * not fall back to a footer mining: the removed content would be unreachable
+	 * because the viewer would have nothing to scroll over.
+	 */
+	@Test
+	public void testRemovingTheWholeContentStaysScrollable() {
+		setEditorContent("");
+		String removed = "a removed line\n".repeat(200);
+
+		assertTrue(UnifiedDiff.create(editor, removed, UnifiedDiffMode.OVERLAY_READ_ONLY_MODE).open().isOK());
+
+		StyledText widget = viewer().getTextWidget();
+		int reserved = waitForVerticalIndent(widget);
+		assertTrue(reserved >= 200 * widget.getLineHeight(),
+				"the 200 removed lines must reserve scrollable space, but only " + reserved + " pixels were reserved");
+	}
+
+	/**
 	 * Opening a second diff on the same editor must replace the first one instead
 	 * of stacking annotations and diffs on top of each other.
 	 */
@@ -408,6 +427,20 @@ public class UnifiedDiffManagerTest {
 
 	private static int countAnnotations(IAnnotationModel model, String type) {
 		return annotations(model, type).size();
+	}
+
+	/**
+	 * The vertical indent of a line is only applied while the code mining is
+	 * painted, and the minings themselves are resolved asynchronously.
+	 */
+	private static int waitForVerticalIndent(StyledText widget) {
+		long deadline = System.currentTimeMillis() + 10_000;
+		int indent = 0;
+		while (indent == 0 && System.currentTimeMillis() < deadline) {
+			forcePaintCycle(widget);
+			indent = widget.getLineVerticalIndent(0);
+		}
+		return indent;
 	}
 
 	private static void forcePaintCycle(StyledText tw) {


### PR DESCRIPTION
When the whole content of a file is removed, the unified diff shows every deleted line as a code mining on an empty document. That mining was created as a document footer mining, and a footer mining reserves no height in the text widget, so the viewer had nothing to scroll over and the deleted content was unreachable as soon as it exceeded the visible area.

A diff offset that starts a line now gets a line header mining instead, which reserves its height as the vertical indent of its line. This covers an emptied document as well as every document ending with a line delimiter; only content behind a last line without a trailing delimiter still needs a footer mining. The mining position is also clamped to the document, because the annotation model silently drops a position that reaches beyond the end.

Covered by a new test in `UnifiedDiffManagerTest` that empties the editor, opens an overlay diff of 200 removed lines and asserts the reserved space. It fails without the change.