### PR TITLE
Null safe compare backport

### DIFF
--- a/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
+++ b/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
-Bundle-Version: 3.33.0.qualifier
+Bundle-Version: 3.33.1.qualifier
 Bundle-SymbolicName: org.eclipse.core.runtime; singleton:=true
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.core.internal.runtime.PlatformActivator

--- a/runtime/bundles/org.eclipse.core.runtime/forceQualifierUpdate.txt
+++ b/runtime/bundles/org.eclipse.core.runtime/forceQualifierUpdate.txt
@@ -6,3 +6,6 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/11
 XML Refactoring
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+https://github.com/eclipse-platform/eclipse.platform.ui/issues/3604
+https://github.com/eclipse-platform/eclipse.platform/issues/2872
+https://github.com/eclipse-platform/eclipse.platform/pull/2319

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/InternalPlatform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/internal/runtime/InternalPlatform.java
@@ -462,7 +462,11 @@ public final class InternalPlatform {
 	}
 
 	public String getOS() {
-		return getContextProperty(PROP_OS);
+		String property = getContextProperty(PROP_OS);
+		if (property == null) {
+			return Platform.OS_UNKNOWN;
+		}
+		return property;
 	}
 
 	public String getWS() {

--- a/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
+++ b/runtime/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
@@ -22,6 +22,7 @@ import java.nio.charset.Charset;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Objects;
 import java.util.ResourceBundle;
 import org.eclipse.core.internal.runtime.AuthorizationHandler;
 import org.eclipse.core.internal.runtime.InternalPlatform;
@@ -79,7 +80,7 @@ public final class Platform {
 		 * @since 3.30
 		 */
 		public static boolean is(String osString) {
-			return Platform.getOS().equals(osString);
+			return Objects.equals(Platform.getOS(), osString);
 		}
 
 		/**


### PR DESCRIPTION
This is a backport of commit ade30dabee from eclipse-platform/eclipse.platform#2319 targeting the R4_35_maintenance branch.

When Eclipse is launched outside of the Equinox launcher (e.g. without `eclipse.ini`), no `-Dosgi.os` argument is passed, which means `Platform.getOS()` returns **null**. This caused an **NPE** in InternalPlatform due to a null-unsafe comparison. 
Here, even passing a random or blank string value for `-Dosgi.os` is enough to launch Eclipse successfully. The Equinox launcher normally avoids this problem entirely because it reads the operating system from the environment and sets the value itself — either via **eclipse.ini** or through an internal code path — so this NPE is never triggered when launching through the standard launcher.

The fix ensures that Platform.OS_UNKNOWN is returned instead of performing an unsafe null comparison, making `Platform.getOS() `null-safe regardless of how Eclipse is launched. This was reported in eclipse.platform.ui[#3604](https://github.com/eclipse-platform/eclipse.platform.ui/issues/3604) and eclipse.platform[#2872](https://github.com/eclipse-platform/eclipse.platform/issues/2872). 
The bundle version has been bumped to 3.33.1 accordingly.