### PR TITLE
Show the unified diff when a file exists on one side only

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 import java.util.ResourceBundle;
 
 import org.eclipse.compare.CompareConfiguration;
+import org.eclipse.compare.CompareEditorInput;
 import org.eclipse.compare.CompareNavigator;
 import org.eclipse.compare.CompareUI;
 import org.eclipse.compare.ICompareNavigator;
@@ -4196,6 +4197,34 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 				new MergeSourceViewer[] { fLeft, fRight, fAncestor },
 				AbstractDecoratedTextEditorPreferenceConstants.EDITOR_LINE_NUMBER_RULER);
 		fHandlerService.registerAction(toggleLineNumbersAction, ITextEditorActionDefinitionIds.LINENUMBER_TOGGLE);
+
+		createShowUnifiedDiffItem(tbm);
+	}
+
+	/**
+	 * Adds the action that switches this side by side comparison over to the
+	 * unified diff, the counterpart of the unified diff's action to open the
+	 * comparison. Only added when the input can be shown as a unified diff at all.
+	 */
+	private void createShowUnifiedDiffItem(ToolBarManager tbm) {
+		if (!(getCompareConfiguration().getContainer() instanceof CompareEditorInput input)
+				|| !CompareUIPlugin.canShowAsUnifiedDiff(input)) {
+			return;
+		}
+		Action showUnifiedDiff = new Action() {
+			@Override
+			public void run() {
+				CompareUIPlugin.getDefault().switchToUnifiedDiff(input, getWorkbenchPage(input));
+			}
+		};
+		Utilities.initAction(showUnifiedDiff, getResourceBundle(), "action.ShowUnifiedDiff."); //$NON-NLS-1$
+		tbm.add(new Separator());
+		tbm.add(new ActionContributionItem(showUnifiedDiff));
+	}
+
+	private static IWorkbenchPage getWorkbenchPage(CompareEditorInput input) {
+		IWorkbenchPart part = input.getWorkbenchPart();
+		return part == null ? null : part.getSite().getPage();
 	}
 
 	private void configureCompareFilterActions(Object input, Object ancestor,

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewerResources.properties
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewerResources.properties
@@ -115,3 +115,7 @@ Editor.FindReplace.description=Find/Replace
 
 action.IgnoreWhiteSpace.label=&Ignore White Space
 action.IgnoreWhiteSpace.tooltip=Ignore White Space Where Applicable
+
+action.ShowUnifiedDiff.label=Show Unified Diff
+action.ShowUnifiedDiff.tooltip=Show the comparison as a unified diff
+action.ShowUnifiedDiff.image=unifieddiff_co.svg

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -855,7 +855,41 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 			CompareUIPlugin.log(e);
 			return null;
 		}
-		if (!(input.getCompareResult() instanceof ICompareInput compareInput)) {
+		return unifiedDiffSourceOf(input);
+	}
+
+	/**
+	 * Collects what the unified diff needs from an input that has already been run.
+	 * Reads the side that supplies the diff, so it must not be called on the UI
+	 * thread. Returns <code>null</code> if the input cannot be shown as a unified
+	 * diff.
+	 */
+	private UnifiedDiffSource unifiedDiffSourceOf(CompareEditorInput input) {
+		UnifiedDiffCandidate candidate = unifiedDiffCandidateOf(input);
+		if (candidate == null) {
+			return null;
+		}
+		// The other side supplies the diff source and is read here rather than on the
+		// UI thread.
+		return new UnifiedDiffSource(candidate.compareInput(), candidate.editorInput(), candidate.element(),
+				candidate.mode(), getSourceOf(candidate.diffSource()));
+	}
+
+	/**
+	 * Returns whether the result of the given input can be displayed as a unified
+	 * diff. Answers from the structure of the compare result alone, without reading
+	 * any content, so it is cheap enough for deciding whether to offer the switch.
+	 */
+	public static boolean canShowAsUnifiedDiff(CompareEditorInput input) {
+		return unifiedDiffCandidateOf(input) != null;
+	}
+
+	/**
+	 * Picks the side the unified diff sits on, without reading any content.
+	 * Returns <code>null</code> if neither side qualifies.
+	 */
+	private static UnifiedDiffCandidate unifiedDiffCandidateOf(CompareEditorInput input) {
+		if (input == null || !(input.getCompareResult() instanceof ICompareInput compareInput)) {
 			return null;
 		}
 		// A common ancestor (3-way input) is ignored; the unified diff renders a
@@ -869,17 +903,58 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 			return null;
 		}
 		// The overlay needs a workspace file to sit on; an editor opened on anything
-		// else, a revision for example, comes up empty. The other side supplies the
-		// diff source and is read here rather than on the UI thread.
+		// else, a revision for example, comes up empty.
 		if (leftEditorInput instanceof IFileEditorInput) {
-			return new UnifiedDiffSource(compareInput, leftEditorInput, left, UnifiedDiffMode.REVERT_MODE,
-					getSourceOf(rightSource));
+			return new UnifiedDiffCandidate(compareInput, leftEditorInput, left, UnifiedDiffMode.REVERT_MODE,
+					rightSource);
 		}
 		if (rightEditorInput instanceof IFileEditorInput) {
-			return new UnifiedDiffSource(compareInput, rightEditorInput, right, UnifiedDiffMode.OVERLAY_READ_ONLY_MODE,
-					getSourceOf(leftSource));
+			return new UnifiedDiffCandidate(compareInput, rightEditorInput, right,
+					UnifiedDiffMode.OVERLAY_READ_ONLY_MODE, leftSource);
 		}
 		return null;
+	}
+
+	/**
+	 * Switches the compare editor showing the given input over to the unified diff.
+	 * The compare editor is closed once the unified diff is up; when it cannot be
+	 * shown, the compare editor is left as it is.
+	 */
+	public void switchToUnifiedDiff(final CompareEditorInput input, final IWorkbenchPage page) {
+		final IWorkbenchPage wpage = page != null ? page : getActivePage();
+		if (wpage == null || !canShowAsUnifiedDiff(input)) {
+			return;
+		}
+		Job job = new Job(NLS.bind(CompareMessages.UnifiedDiff_preparing, input.getTitle())) {
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				// The input already ran, so only the diff source has to be read here.
+				UnifiedDiffSource source = unifiedDiffSourceOf(input);
+				if (source == null || monitor.isCanceled()) {
+					return Status.CANCEL_STATUS;
+				}
+				Display.getDefault().asyncExec(() -> {
+					IEditorPart compareEditor = wpage.findEditor(input);
+					if (openUnifiedDiff(source, input, wpage, null, true) && compareEditor != null) {
+						// Prompts when the merge has unsaved changes.
+						wpage.closeEditor(compareEditor, true);
+					}
+				});
+				return Status.OK_STATUS;
+			}
+
+			@Override
+			public boolean belongsTo(Object family) {
+				return family == input || input.belongsTo(family);
+			}
+		};
+		job.setUser(true);
+		job.schedule();
+	}
+
+	/** The side the unified diff would sit on, before any content is read. */
+	private static record UnifiedDiffCandidate(ICompareInput compareInput, IEditorInput editorInput,
+			ITypedElement element, UnifiedDiffMode mode, IStreamContentAccessor diffSource) {
 	}
 
 	private static IEditorInput documentKeyOf(ITypedElement element) {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -797,19 +797,20 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 		return openTwoWayCompare;
 	}
 
-	private String getSourceOf(IStreamContentAccessor right) {
+	/**
+	 * Returns the text of the side that is diffed against the editor. An element
+	 * that is absent or carries no contents, as for a file that exists on one side
+	 * only, contributes an empty document, so the whole file shows up as one
+	 * change.
+	 */
+	private String getSourceOf(ITypedElement element) {
 		try {
-			if (right == null) {
-				return ""; //$NON-NLS-1$
+			if (element instanceof IStreamContentAccessor accessor) {
+				return toString(accessor.getContents());
 			}
-			String result = toString(right.getContents());
-			return result;
 		} catch (CoreException | IOException e) {
 			CompareUIPlugin.log(e);
 		}
-		// UnifiedDiff.Builder requires a non-null source. Return an empty string so
-		// the unified diff path can still attempt to open and the fallback to the
-		// classic compare editor remains intact when an OK status is not returned.
 		return ""; //$NON-NLS-1$
 	}
 
@@ -896,21 +897,16 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 		// plain left-vs-right overlay.
 		ITypedElement left = compareInput.getLeft();
 		ITypedElement right = compareInput.getRight();
-		IEditorInput leftEditorInput = documentKeyOf(left);
-		IEditorInput rightEditorInput = documentKeyOf(right);
-		if (leftEditorInput == null || rightEditorInput == null || !(left instanceof IStreamContentAccessor leftSource)
-				|| !(right instanceof IStreamContentAccessor rightSource)) {
-			return null;
+		// Only the side shown in the editor has to be a workspace file; an editor
+		// opened on anything else, a revision for example, comes up empty. The other
+		// side merely supplies the diff source and may be missing entirely, as for a
+		// newly added file.
+		if (documentKeyOf(left) instanceof IFileEditorInput leftEditorInput) {
+			return new UnifiedDiffCandidate(compareInput, leftEditorInput, left, UnifiedDiffMode.REVERT_MODE, right);
 		}
-		// The overlay needs a workspace file to sit on; an editor opened on anything
-		// else, a revision for example, comes up empty.
-		if (leftEditorInput instanceof IFileEditorInput) {
-			return new UnifiedDiffCandidate(compareInput, leftEditorInput, left, UnifiedDiffMode.REVERT_MODE,
-					rightSource);
-		}
-		if (rightEditorInput instanceof IFileEditorInput) {
+		if (documentKeyOf(right) instanceof IFileEditorInput rightEditorInput) {
 			return new UnifiedDiffCandidate(compareInput, rightEditorInput, right,
-					UnifiedDiffMode.OVERLAY_READ_ONLY_MODE, leftSource);
+					UnifiedDiffMode.OVERLAY_READ_ONLY_MODE, left);
 		}
 		return null;
 	}
@@ -954,7 +950,7 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 
 	/** The side the unified diff would sit on, before any content is read. */
 	private static record UnifiedDiffCandidate(ICompareInput compareInput, IEditorInput editorInput,
-			ITypedElement element, UnifiedDiffMode mode, IStreamContentAccessor diffSource) {
+			ITypedElement element, UnifiedDiffMode mode, ITypedElement diffSource) {
 	}
 
 	private static IEditorInput documentKeyOf(ITypedElement element) {

--- a/team/bundles/org.eclipse.compare/icons/full/elcl16/unifieddiff_co.svg
+++ b/team/bundles/org.eclipse.compare/icons/full/elcl16/unifieddiff_co.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect x="1.5" y="1.5" width="13" height="13" rx="1" fill="#fafcf4" stroke="#8a97ac" stroke-width="1"/>
+  <rect x="3.5" y="4" width="9" height="1.5" fill="#8a97ac"/>
+  <rect x="3.5" y="7.25" width="9" height="1.5" fill="#5aa02c"/>
+  <rect x="3.5" y="10.5" width="9" height="1.5" fill="#c9453b"/>
+</svg>

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/UnifiedDiffOpenTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/UnifiedDiffOpenTest.java
@@ -188,6 +188,34 @@ public class UnifiedDiffOpenTest {
 		}
 	}
 
+	/**
+	 * An element that only names the file, as compare inputs use it for a side that
+	 * does not exist, for example the previous version of an added file.
+	 */
+	private static final class AbsentElement implements ITypedElement {
+
+		private final String name;
+
+		AbsentElement(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public String getType() {
+			return UNKNOWN_TYPE;
+		}
+
+		@Override
+		public Image getImage() {
+			return null;
+		}
+	}
+
 	/** Records prepareInput invocations and the thread they ran on. */
 	private static final class RecordingCompareEditorInput extends CompareEditorInput {
 
@@ -249,19 +277,36 @@ public class UnifiedDiffOpenTest {
 	public void testUnifiedEditorOpensForWorkspaceFileInput() throws Exception {
 		RecordingCompareEditorInput input = openQualifyingInput();
 
-		IEditorPart editorPart = activePage().getActiveEditor();
-		assertNotNull(editorPart, "an editor must be open"); //$NON-NLS-1$
-		assertFalse(editorPart instanceof CompareEditor,
-				"a qualifying input must open a text editor, not the compare editor"); //$NON-NLS-1$
-		ITextEditor textEditor = assertInstanceOf(ITextEditor.class, editorPart);
-		IFileEditorInput editorInput = assertInstanceOf(IFileEditorInput.class, textEditor.getEditorInput());
-		assertEquals("left.txt", editorInput.getFile().getName()); //$NON-NLS-1$
-
-		IAnnotationModel model = textEditor.getDocumentProvider().getAnnotationModel(textEditor.getEditorInput());
-		assertNotNull(model, "the unified diff editor must have an annotation model"); //$NON-NLS-1$
-		pumpUntil(() -> hasUnifiedDiffAnnotation(model), "unified diff annotations did not appear"); //$NON-NLS-1$
-
+		assertUnifiedDiffEditor("left.txt"); //$NON-NLS-1$
 		assertEquals(1, input.prepareInputCount.get(), "prepareInput must run exactly once per unified open"); //$NON-NLS-1$
+	}
+
+	/**
+	 * A file that exists on one side only, an added file for example, is shown as a
+	 * unified diff of the whole file; the absent side contributes an empty document.
+	 */
+	@Test
+	public void testUnifiedEditorOpensWhenOtherSideIsNull() throws Exception {
+		IFile left = createFile("left.txt", "alpha\nbravo\ncharlie\n"); //$NON-NLS-1$ //$NON-NLS-2$
+		openInput(new WorkspaceFileElement(left), null);
+
+		assertUnifiedDiffEditor("left.txt"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testUnifiedEditorOpensWhenOtherSideHasNoContents() throws Exception {
+		IFile left = createFile("left.txt", "alpha\nbravo\ncharlie\n"); //$NON-NLS-1$ //$NON-NLS-2$
+		openInput(new WorkspaceFileElement(left), new AbsentElement("left.txt")); //$NON-NLS-1$
+
+		assertUnifiedDiffEditor("left.txt"); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testUnifiedEditorOpensOnRightWhenLeftIsAbsent() throws Exception {
+		IFile right = createFile("right.txt", "alpha\nbravo\ncharlie\n"); //$NON-NLS-1$ //$NON-NLS-2$
+		openInput(new AbsentElement("right.txt"), new WorkspaceFileElement(right)); //$NON-NLS-1$
+
+		assertUnifiedDiffEditor("right.txt"); //$NON-NLS-1$
 	}
 
 	@Test
@@ -434,11 +479,29 @@ public class UnifiedDiffOpenTest {
 	private RecordingCompareEditorInput openQualifyingInput() throws CoreException {
 		IFile left = createFile("left.txt", "alpha\nbravo\ncharlie\ndelta\n"); //$NON-NLS-1$ //$NON-NLS-2$
 		IFile right = createFile("right.txt", "alpha\nBRAVO\ncharlie\ndelta\n"); //$NON-NLS-1$ //$NON-NLS-2$
-		RecordingCompareEditorInput input = new RecordingCompareEditorInput(
-				new WorkspaceFileElement(left), new WorkspaceFileElement(right));
+		return openInput(new WorkspaceFileElement(left), new WorkspaceFileElement(right));
+	}
+
+	private RecordingCompareEditorInput openInput(ITypedElement left, ITypedElement right) {
+		RecordingCompareEditorInput input = new RecordingCompareEditorInput(left, right);
 		CompareUI.openCompareEditor(input);
 		pumpUntil(() -> activePage().getActiveEditor() != null, "no editor opened"); //$NON-NLS-1$
 		return input;
+	}
+
+	/** Asserts that the unified diff is shown in a text editor on the given file. */
+	private static void assertUnifiedDiffEditor(String fileName) {
+		IEditorPart editorPart = activePage().getActiveEditor();
+		assertNotNull(editorPart, "an editor must be open"); //$NON-NLS-1$
+		assertFalse(editorPart instanceof CompareEditor,
+				"a qualifying input must open a text editor, not the compare editor"); //$NON-NLS-1$
+		ITextEditor textEditor = assertInstanceOf(ITextEditor.class, editorPart);
+		IFileEditorInput editorInput = assertInstanceOf(IFileEditorInput.class, textEditor.getEditorInput());
+		assertEquals(fileName, editorInput.getFile().getName());
+
+		IAnnotationModel model = textEditor.getDocumentProvider().getAnnotationModel(textEditor.getEditorInput());
+		assertNotNull(model, "the unified diff editor must have an annotation model"); //$NON-NLS-1$
+		pumpUntil(() -> hasUnifiedDiffAnnotation(model), "unified diff annotations did not appear"); //$NON-NLS-1$
 	}
 
 	private IFile createFile(String name, String content) throws CoreException {

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/UnifiedDiffOpenTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/UnifiedDiffOpenTest.java
@@ -28,6 +28,8 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
+import java.util.Locale;
+import java.util.ResourceBundle;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 
@@ -39,9 +41,11 @@ import org.eclipse.compare.IResourceProvider;
 import org.eclipse.compare.ISharedDocumentAdapter;
 import org.eclipse.compare.ITypedElement;
 import org.eclipse.compare.SharedDocumentAdapter;
+import org.eclipse.compare.contentmergeviewer.TextMergeViewer;
 import org.eclipse.compare.internal.CompareEditor;
 import org.eclipse.compare.internal.ComparePreferencePage;
 import org.eclipse.compare.internal.CompareUIPlugin;
+import org.eclipse.compare.internal.Utilities;
 import org.eclipse.compare.unifieddiff.internal.UnifiedDiffManager;
 import org.eclipse.compare.structuremergeviewer.DiffNode;
 import org.eclipse.core.resources.IFile;
@@ -52,6 +56,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.action.Action;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.Annotation;
@@ -338,6 +343,78 @@ public class UnifiedDiffOpenTest {
 				"an editor the unified diff did not open must stay open"); //$NON-NLS-1$
 		assertEquals(2, activePage().getEditorReferences().length,
 				"the pre-opened editor and the compare editor must both be open"); //$NON-NLS-1$
+	}
+
+	/**
+	 * The switch is only offered for a comparison the unified diff can actually
+	 * display, so the toolbar of an input without a workspace file stays clean.
+	 */
+	@Test
+	public void testOnlyAQualifyingInputCanBeShownAsUnifiedDiff() throws Exception {
+		RecordingCompareEditorInput qualifying = openClassicInput();
+		assertTrue(CompareUIPlugin.canShowAsUnifiedDiff(qualifying),
+				"a workspace file comparison must offer the unified diff"); //$NON-NLS-1$
+
+		RecordingCompareEditorInput inMemory = new RecordingCompareEditorInput(
+				new InMemoryElement("left.txt", "alpha\nbravo\n"), //$NON-NLS-1$ //$NON-NLS-2$
+				new InMemoryElement("right.txt", "alpha\nBRAVO\n")); //$NON-NLS-1$ //$NON-NLS-2$
+		CompareUI.openCompareEditor(inMemory);
+		pumpUntil(() -> inMemory.getCompareResult() != null, "the in-memory input was not prepared"); //$NON-NLS-1$
+		assertFalse(CompareUIPlugin.canShowAsUnifiedDiff(inMemory),
+				"an input without a workspace file must not offer the unified diff"); //$NON-NLS-1$
+	}
+
+	/**
+	 * Switching a side by side comparison over to the unified diff must leave the
+	 * unified diff behind, not both editors.
+	 */
+	@Test
+	public void testSwitchToUnifiedDiffReplacesTheCompareEditor() throws Exception {
+		RecordingCompareEditorInput input = openClassicInput();
+		int prepareInputCountBeforeSwitch = input.prepareInputCount.get();
+
+		CompareUIPlugin.getDefault().switchToUnifiedDiff(input, activePage());
+		pumpUntil(() -> activePage().getActiveEditor() instanceof ITextEditor,
+				"the unified diff editor did not open"); //$NON-NLS-1$
+
+		ITextEditor textEditor = assertInstanceOf(ITextEditor.class, activePage().getActiveEditor());
+		IAnnotationModel model = textEditor.getDocumentProvider().getAnnotationModel(textEditor.getEditorInput());
+		assertNotNull(model, "the unified diff editor must have an annotation model"); //$NON-NLS-1$
+		pumpUntil(() -> hasUnifiedDiffAnnotation(model), "unified diff annotations did not appear"); //$NON-NLS-1$
+
+		assertFalse(hasCompareEditor(), "the compare editor must close when the unified diff takes over"); //$NON-NLS-1$
+		assertEquals(1, activePage().getEditorReferences().length,
+				"switching must leave exactly one editor open"); //$NON-NLS-1$
+		assertEquals(prepareInputCountBeforeSwitch, input.prepareInputCount.get(),
+				"switching must reuse the already prepared input"); //$NON-NLS-1$
+	}
+
+	/** A missing resource key would leave the toolbar button blank. */
+	@Test
+	public void testShowUnifiedDiffActionIsFullyDescribed() {
+		ResourceBundle bundle = ResourceBundle.getBundle("org.eclipse.compare.contentmergeviewer.TextMergeViewerResources", //$NON-NLS-1$
+				Locale.getDefault(), TextMergeViewer.class.getClassLoader());
+		Action action = new Action() {
+			// nothing to run, only the presentation is inspected
+		};
+		Utilities.initAction(action, bundle, "action.ShowUnifiedDiff."); //$NON-NLS-1$
+
+		assertEquals("Show Unified Diff", action.getText(), "the action needs a label"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNotNull(action.getToolTipText(), "the action needs a tooltip"); //$NON-NLS-1$
+		assertNotNull(action.getImageDescriptor(), "the action needs an icon"); //$NON-NLS-1$
+	}
+
+	/** Opens the qualifying input in the classic compare editor. */
+	private RecordingCompareEditorInput openClassicInput() throws CoreException {
+		store().setValue(ComparePreferencePage.UNIFIED_DIFF, false);
+		IFile left = createFile("left.txt", "alpha\nbravo\ncharlie\ndelta\n"); //$NON-NLS-1$ //$NON-NLS-2$
+		IFile right = createFile("right.txt", "alpha\nBRAVO\ncharlie\ndelta\n"); //$NON-NLS-1$ //$NON-NLS-2$
+		RecordingCompareEditorInput input = new RecordingCompareEditorInput(new WorkspaceFileElement(left),
+				new WorkspaceFileElement(right));
+		CompareUI.openCompareEditor(input);
+		pumpUntil(UnifiedDiffOpenTest::hasCompareEditor, "the compare editor did not open"); //$NON-NLS-1$
+		pumpUntil(() -> input.getCompareResult() != null, "the compare input was not prepared"); //$NON-NLS-1$
+		return input;
 	}
 
 	private static String defaultEditorIdFor(IFile file) {


### PR DESCRIPTION
The unified diff only opened when both sides of a compare input provided a document key and stream contents. A file that exists on one side only, an added file for example, fails that check because compare inputs represent the missing side with a bare element that just names the file, or with no element at all, so the classic compare editor opened instead.

Only the side that hosts the editor has to be a workspace file now; the other side merely supplies the text to diff against and contributes an empty document when it is absent, which renders the whole file as one change. In the candidate/source split this means UnifiedDiffCandidate carries the other side as an ITypedElement rather than an IStreamContentAccessor, so picking a candidate stays free of content reads and canShowAsUnifiedDiff remains cheap. Three new tests in UnifiedDiffOpenTest cover a null side, a side without contents, and the mirrored case where the left side is the absent one; all three fail without the change.

This is the first half of #2868. A file deleted in the workspace is handled in #2875. Stacked on #2854, whose commit appears here until that one merges.