### PR TITLE
Offer the switch to the unified diff only when it is enabled

### DIFF
--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/contentmergeviewer/TextMergeViewer.java
@@ -4204,11 +4204,12 @@ public class TextMergeViewer extends ContentMergeViewer implements IAdaptable {
 	/**
 	 * Adds the action that switches this side by side comparison over to the
 	 * unified diff, the counterpart of the unified diff's action to open the
-	 * comparison. Only added when the input can be shown as a unified diff at all.
+	 * comparison. Only added when the unified diff is enabled in the preferences
+	 * and the input can be shown as one at all.
 	 */
 	private void createShowUnifiedDiffItem(ToolBarManager tbm) {
 		if (!(getCompareConfiguration().getContainer() instanceof CompareEditorInput input)
-				|| !CompareUIPlugin.canShowAsUnifiedDiff(input)) {
+				|| !CompareUIPlugin.canOfferUnifiedDiffSwitch(input)) {
 			return;
 		}
 		Action showUnifiedDiff = new Action() {

--- a/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
+++ b/team/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/CompareUIPlugin.java
@@ -898,6 +898,20 @@ public final class CompareUIPlugin extends AbstractUIPlugin {
 	}
 
 	/**
+	 * Returns whether the classic compare editor may offer a switch to the unified
+	 * diff for the given input. The unified diff is still experimental, so the
+	 * switch stays hidden until the preference that enables it is set.
+	 */
+	public static boolean canOfferUnifiedDiffSwitch(CompareEditorInput input) {
+		if (input == null) {
+			return false;
+		}
+		CompareConfiguration configuration = input.getCompareConfiguration();
+		IPreferenceStore store = configuration == null ? null : configuration.getPreferenceStore();
+		return store != null && store.getBoolean(ComparePreferencePage.UNIFIED_DIFF) && canShowAsUnifiedDiff(input);
+	}
+
+	/**
 	 * Picks the side the unified diff sits on, without reading any content.
 	 * Returns <code>null</code> if neither side qualifies.
 	 */

--- a/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/UnifiedDiffOpenTest.java
+++ b/team/tests/org.eclipse.compare.tests/src/org/eclipse/compare/tests/UnifiedDiffOpenTest.java
@@ -57,6 +57,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -594,6 +595,33 @@ public class UnifiedDiffOpenTest {
 		pumpUntil(() -> inMemory.getCompareResult() != null, "the in-memory input was not prepared"); //$NON-NLS-1$
 		assertFalse(CompareUIPlugin.canShowAsUnifiedDiff(inMemory),
 				"an input without a workspace file must not offer the unified diff"); //$NON-NLS-1$
+	}
+
+	/**
+	 * The unified diff is experimental, so the switch is only offered while the
+	 * preference that enables it is set, and then only for a comparison the unified
+	 * diff can display.
+	 */
+	@Test
+	public void testTheSwitchIsOnlyOfferedWhileTheUnifiedDiffIsEnabled() throws Exception {
+		RecordingCompareEditorInput input = openClassicInput();
+		assertTrue(CompareUIPlugin.canShowAsUnifiedDiff(input),
+				"a workspace file comparison must qualify for the unified diff"); //$NON-NLS-1$
+		assertFalse(CompareUIPlugin.canOfferUnifiedDiffSwitch(input),
+				"a disabled unified diff must not be offered"); //$NON-NLS-1$
+
+		store().setValue(ComparePreferencePage.UNIFIED_DIFF, true);
+		assertTrue(CompareUIPlugin.canOfferUnifiedDiffSwitch(input),
+				"an enabled unified diff must be offered for a qualifying comparison"); //$NON-NLS-1$
+
+		// Prepared without an editor: opening one would leave the fallback to the
+		// classic editor pending past the end of this test.
+		RecordingCompareEditorInput inMemory = new RecordingCompareEditorInput(
+				new InMemoryElement("left.txt", "alpha\nbravo\n"), //$NON-NLS-1$ //$NON-NLS-2$
+				new InMemoryElement("right.txt", "alpha\nBRAVO\n")); //$NON-NLS-1$ //$NON-NLS-2$
+		inMemory.run(new NullProgressMonitor());
+		assertFalse(CompareUIPlugin.canOfferUnifiedDiffSwitch(inMemory),
+				"an enabled unified diff must not be offered for a comparison it cannot display"); //$NON-NLS-1$
 	}
 
 	/**


### PR DESCRIPTION
The compare editor showed the button that switches an open comparison over to the unified diff for every comparison the unified diff can display, no matter whether the experimental preference that enables the unified diff was set. The button slipped into master with #2874 earlier than intended, and @tobiasmelcher asked in #2854 to gate it on that preference.

The button now follows the preference and stays hidden while it is off, so users who did not opt into the experiment do not see it. The check reads the same preference store that decides which editor an input opens in, which means the button appears exactly when reopening the same comparison would bring up the unified diff. `canShowAsUnifiedDiff` stays free of the preference so that switching keeps working for an editor that was opened while the preference was on and had it turned off afterwards.

The existing test class covers both states of the preference for a qualifying comparison, plus a comparison the unified diff cannot display while the preference is on.