### PR TITLE
skip restoring terminals with missing working directory

### DIFF
--- a/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/view/TerminalsViewMementoHandler.java
+++ b/terminal/bundles/org.eclipse.terminal.view.ui/src/org/eclipse/terminal/view/ui/internal/view/TerminalsViewMementoHandler.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.terminal.view.ui.internal.view;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -154,43 +155,48 @@ public class TerminalsViewMementoHandler {
 			// Get all the "connection" memento's.
 			IMemento[] connections = memento.getChildren("connection"); //$NON-NLS-1$
 			for (IMemento connection : connections) {
-				// Create the properties container that holds the terminal properties
-				Map<String, Object> properties = new HashMap<>();
-
-				// Set the view id attributes
-				properties.put(ITerminalsConnectorConstants.PROP_ID, id);
-				properties.put(ITerminalsConnectorConstants.PROP_SECONDARY_ID, secondaryId);
-
-				// Restore the common attributes
-				properties.put(ITerminalsConnectorConstants.PROP_DELEGATE_ID,
-						connection.getString(ITerminalsConnectorConstants.PROP_DELEGATE_ID));
-				properties.put(ITerminalsConnectorConstants.PROP_TERMINAL_CONNECTOR_ID,
-						connection.getString(ITerminalsConnectorConstants.PROP_TERMINAL_CONNECTOR_ID));
-				if (connection.getBoolean(ITerminalsConnectorConstants.PROP_FORCE_NEW) != null) {
-					properties.put(ITerminalsConnectorConstants.PROP_FORCE_NEW,
-							connection.getBoolean(ITerminalsConnectorConstants.PROP_FORCE_NEW));
-				}
-
-				// Restore the encoding
-				if (connection.getString(ITerminalsConnectorConstants.PROP_ENCODING) != null) {
-					properties.put(ITerminalsConnectorConstants.PROP_ENCODING,
-							connection.getString(ITerminalsConnectorConstants.PROP_ENCODING));
-				}
-
-				// Restore the working directory
-				if (connection.getString(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR) != null) {
-					properties.put(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR,
-							connection.getString(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR));
-				}
-				Optional<ILauncherDelegate> delegate = findDelegate(properties);
-				// Pass on to the memento handler
-				delegate.map(d -> d.getAdapter(IMementoHandler.class))
-						.ifPresent(mh -> mh.restoreState(connection, properties));
-				// Restore the terminal connection
-				delegate.ifPresent(d -> executeDelegate(properties, d));
-
+				restoreConnection(id, secondaryId, connection);
 			}
 		}
+	}
+
+	private void restoreConnection(String id, String secondaryId, IMemento connection) {
+		// Create the properties container that holds the terminal properties
+		Map<String, Object> properties = new HashMap<>();
+
+		// Set the view id attributes
+		properties.put(ITerminalsConnectorConstants.PROP_ID, id);
+		properties.put(ITerminalsConnectorConstants.PROP_SECONDARY_ID, secondaryId);
+
+		// Restore the common attributes
+		properties.put(ITerminalsConnectorConstants.PROP_DELEGATE_ID,
+				connection.getString(ITerminalsConnectorConstants.PROP_DELEGATE_ID));
+		properties.put(ITerminalsConnectorConstants.PROP_TERMINAL_CONNECTOR_ID,
+				connection.getString(ITerminalsConnectorConstants.PROP_TERMINAL_CONNECTOR_ID));
+		if (connection.getBoolean(ITerminalsConnectorConstants.PROP_FORCE_NEW) != null) {
+			properties.put(ITerminalsConnectorConstants.PROP_FORCE_NEW,
+					connection.getBoolean(ITerminalsConnectorConstants.PROP_FORCE_NEW));
+		}
+
+		// Restore the encoding
+		if (connection.getString(ITerminalsConnectorConstants.PROP_ENCODING) != null) {
+			properties.put(ITerminalsConnectorConstants.PROP_ENCODING,
+					connection.getString(ITerminalsConnectorConstants.PROP_ENCODING));
+		}
+
+		// Restore the working directory
+		String workingDirectory = connection.getString(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR);
+		if (workingDirectory != null) {
+			if (!new File(workingDirectory).isDirectory()) {
+				return;
+			}
+			properties.put(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR, workingDirectory);
+		}
+		Optional<ILauncherDelegate> delegate = findDelegate(properties);
+		// Pass on to the memento handler
+		delegate.map(d -> d.getAdapter(IMementoHandler.class)).ifPresent(mh -> mh.restoreState(connection, properties));
+		// Restore the terminal connection
+		delegate.ifPresent(d -> executeDelegate(properties, d));
 	}
 
 	private Optional<ILauncherDelegate> findDelegate(Map<String, Object> properties) {


### PR DESCRIPTION
Since we already have M3 now, this may be better for Eclipse 2026-12 but that's a decision for committers.

---

With restoring terminals now [properly restoring the working directory](https://github.com/eclipse-platform/eclipse.platform/pull/2859), it doesn't really make sense to restore terminals pointing to a directory that no longer exists so this PR skips restoring these terminals (see also #2859).

I also used this chance to extract the logic for restoring a single terminal from the stored connection properties into a method for better readability.