### PR TITLE
Fix InputStreamMonitor.writeNext() wait() not in loop

### DIFF
--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/InputStreamMonitor.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/InputStreamMonitor.java
@@ -186,7 +186,8 @@ public class InputStreamMonitor {
 			synchronized(fLock) {
 				// Queue could receive more input between last empty check and
 				// lock acquire. See https://bugs.eclipse.org/550834
-				if (fQueue.isEmpty()) {
+				// Use while instead of if to guard against spurious wakeups.
+				while (fQueue.isEmpty() && !fClosed) {
 					fLock.wait();
 				}
 			}


### PR DESCRIPTION
## Summary
- Change `if (fQueue.isEmpty())` to `while (fQueue.isEmpty() && !fClosed)` around `fLock.wait()` in `writeNext()` to guard against spurious wakeups per [JLS 17.2.1](https://docs.oracle.com/javase/specs/jls/se17/html/jls-17.html#jls-17.2.1)
- Also checks `!fClosed` to avoid waiting on a closed stream

The existing `if` guard was added for [bug 550834](https://bugs.eclipse.org/550834) but doesn't protect against spurious wakeups. Found via SpotBugs static analysis (WA_NOT_IN_LOOP).

Fixes #2881

## Test plan
- [ ] Existing `InputStreamMonitorTests` pass
- [ ] Manual verification: launch a process, write to its stdin, verify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)