### PR TITLE
Avoid a second tree lookup in Workspace.getResourceInfo

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
@@ -1870,14 +1870,14 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 				Assert.isNotNull(info, "Tree root info must never be null"); //$NON-NLS-1$
 				return info;
 			}
-			ResourceInfo result = null;
-			if (!tree.includes(path)) {
-				return null;
-			}
+			ResourceInfo result;
 			if (mutable) {
+				if (!tree.includes(path)) {
+					return null;
+				}
 				result = (ResourceInfo) tree.openElementData(path);
 			} else {
-				result = (ResourceInfo) tree.getElementData(path);
+				result = (ResourceInfo) tree.getElementDataOrNull(path);
 			}
 			if (result != null && (!phantom && result.isSet(M_PHANTOM))) {
 				return null;

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/watson/ElementTree.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/watson/ElementTree.java
@@ -385,6 +385,26 @@ public class ElementTree {
 	}
 
 	/**
+	 * Returns the element data for the given element identifier, or
+	 * <code>null</code> if the element is not present in this tree.
+	 * <p>
+	 * Unlike {@link #includes(IPath)} followed by {@link #getElementData(IPath)}
+	 * this performs at most one tree lookup.
+	 */
+	public Object getElementDataOrNull(IPath key) {
+		if (key.isRoot()) {
+			return null;
+		}
+		synchronized (this) {
+			DataTreeLookup lookup = lookupCache; // Grab it in case it's replaced concurrently.
+			if (lookup == null || lookup.key != key) {
+				lookupCache = lookup = tree.lookup(key);
+			}
+			return lookup.isPresent ? lookup.data : null;
+		}
+	}
+
+	/**
 	 * Returns the element data for the given element identifier.
 	 * The given element must be present in this tree.
 	 */

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/watson/AllWatsonTests.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/watson/AllWatsonTests.java
@@ -22,6 +22,7 @@ import org.junit.platform.suite.api.Suite;
 		DeltaFlatteningTest.class, //
 		ElementTreeDeltaChainTest.class, //
 		ElementTreeIteratorTest.class, //
+		ElementTreeGetElementDataOrNullTest.class, //
 		ElementTreeHasChangesTest.class, //
 		TreeFlatteningTest.class, //
 })

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/watson/ElementTreeGetElementDataOrNullTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/watson/ElementTreeGetElementDataOrNullTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Vogella GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.core.tests.internal.watson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.eclipse.core.internal.watson.ElementTree;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ElementTree#getElementDataOrNull(org.eclipse.core.runtime.IPath)}.
+ */
+public class ElementTreeGetElementDataOrNullTest implements IPathConstants {
+
+	@Test
+	public void testPresentElementWithData() {
+		ElementTree tree = new ElementTree();
+		tree.createElement(solution, "solution");
+		tree.createElement(project1, "project1");
+
+		assertEquals("project1", tree.getElementDataOrNull(project1));
+		assertEquals(tree.getElementData(project1), tree.getElementDataOrNull(project1));
+	}
+
+	@Test
+	public void testPresentElementWithNullData() {
+		ElementTree tree = new ElementTree();
+		tree.createElement(solution, null);
+
+		assertNull(tree.getElementDataOrNull(solution));
+	}
+
+	@Test
+	public void testAbsentElement() {
+		ElementTree tree = new ElementTree();
+		tree.createElement(solution, "solution");
+
+		assertNull(tree.getElementDataOrNull(project1));
+		assertThrows(IllegalArgumentException.class, () -> tree.getElementData(project1));
+	}
+
+	@Test
+	public void testRoot() {
+		ElementTree tree = new ElementTree();
+
+		assertNull(tree.getElementDataOrNull(root));
+	}
+
+	@Test
+	public void testDeletedElementInDelta() {
+		ElementTree tree = new ElementTree();
+		tree.createElement(solution, "solution");
+		tree.createElement(project1, "project1");
+		tree.immutable();
+
+		ElementTree delta = tree.newEmptyDelta();
+		delta.deleteElement(project1);
+
+		assertNull(delta.getElementDataOrNull(project1));
+		assertEquals("project1", tree.getElementDataOrNull(project1));
+	}
+
+	@Test
+	public void testResultIsIndependentOfLookupCache() {
+		ElementTree tree = new ElementTree();
+		tree.createElement(solution, "solution");
+		tree.createElement(project1, "project1");
+		tree.createElement(project2, "project2");
+
+		// A lookup for another path replaces the single-slot lookup cache.
+		tree.includes(project2);
+		assertEquals("project1", tree.getElementDataOrNull(project1));
+		tree.includes(project2);
+		assertNull(tree.getElementDataOrNull(folder1));
+	}
+}


### PR DESCRIPTION
`Workspace.getResourceInfo` is one of the hottest paths in the resources plug-in, and it walked the element tree twice for every read: once through `ElementTree.includes` and once more through `ElementTree.getElementData`. The single-slot `lookupCache` that is supposed to make the second walk free compares keys by identity and is shared by all threads, so with builders and indexers hitting the same `ElementTree` it gets replaced between the two calls and the second walk runs for real.

This adds the internal `ElementTree.getElementDataOrNull`, which performs one lookup and returns `null` when the element is absent, and uses it for the non-mutable case. That removes a full tree walk plus one monitor acquisition per call. Behavior is unchanged: an absent element and an element with `null` data both already produced `null`. `org.eclipse.core.internal.watson` is internal, so there is no API impact.