### PR TITLE
Skip filter evaluation for projects without resource filters

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectDescription.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ProjectDescription.java
@@ -430,9 +430,10 @@ public class ProjectDescription extends ModelObject implements IProjectDescripti
 	 * Returns the map of filter descriptions (IPath (project relative path) -&gt;
 	 * {@literal LinkedList<FilterDescription>}). Since this method is only used
 	 * internally, it never creates a copy. Returns null if the project does not
-	 * have any filtered resources.
+	 * have any filtered resources. Only the read of the reference is guarded,
+	 * the returned map itself is not.
 	 */
-	public HashMap<IPath, LinkedList<FilterDescription>> getFilters() {
+	synchronized public HashMap<IPath, LinkedList<FilterDescription>> getFilters() {
 		return filterDescriptions;
 	}
 

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Resource.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Resource.java
@@ -2086,7 +2086,7 @@ public abstract class Resource extends PlatformObject implements IResource, ICor
 			return list;
 		}
 		final ProjectDescription description = project.internalGetDescription();
-		if (description == null) {
+		if (description == null || description.getFilters() == null) {
 			return list;
 		}
 		return filterChildren(project, description, list, throwException);


### PR DESCRIPTION
`Resource.filterChildren` runs for every directory scanned by a refresh or an `isSynchronized` walk. Even for a project with no resource filters at all, it allocated two lists and walked the project-relative path to the project root, allocating an `IPath` and taking a synchronized `getFilter` call per segment, only to discard everything.

This returns early when the project description holds no filters. `ProjectDescription.getFilters()` is null exactly in that case, so the check is precise rather than a heuristic, and `isFilteredWithException` already guards the same way. The gain shows up in the auto-refresh polling path, which walks whole projects continuously on Linux. `FilteredResourceTest` passes unchanged.