### PR TITLE
Do not fill in a stack trace for ResourceChangedException

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/IsSynchronizedVisitor.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/localstore/IsSynchronizedVisitor.java
@@ -33,6 +33,12 @@ public class IsSynchronizedVisitor extends CollectSyncStatusVisitor {
 		public ResourceChangedException(IResource target) {
 			this.target = target;
 		}
+
+		@Override
+		public synchronized Throwable fillInStackTrace() {
+			// the stack trace is never used, see the class comment
+			return this;
+		}
 	}
 
 	/**


### PR DESCRIPTION
`IsSynchronizedVisitor` throws `ResourceChangedException` purely as a control-flow signal for the first out-of-sync node, and its only catch site in `FileSystemResourceManager` reads just the target resource. The class comment already states the stack trace is meaningless, so overriding `fillInStackTrace` avoids capturing one.

`RefreshLocalTest` and `UnifiedTreeTest` pass unchanged.