### PR TITLE
Coalesce project encoding validation into a single job

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/CharsetManager.java
@@ -290,6 +290,7 @@ public class CharsetManager implements IManager {
 	private static final String PROJECT_KEY = "<project>"; //$NON-NLS-1$
 	private CharsetDeltaJob charsetListener;
 	CharsetManagerJob job;
+	private ValidateProjectEncoding encodingValidation;
 	private IResourceChangeListener resourceChangeListener;
 	private IPreferenceChangeListener preferenceChangeListener;
 	protected final Bundle systemBundle = Platform.getBundle("org.eclipse.osgi"); //$NON-NLS-1$
@@ -503,7 +504,7 @@ public class CharsetManager implements IManager {
 		try {
 			setResourceEncodingSettings(resourcePath, newCharset, resource);
 			if (resource instanceof Project project) {
-				ValidateProjectEncoding.scheduleProjectValidation(workspace, project);
+				encodingValidation.scheduleProjectValidation(project);
 			}
 		} catch (BackingStoreException e) {
 			setCharsetForHasFailed(resourcePath, e);
@@ -529,10 +530,20 @@ public class CharsetManager implements IManager {
 		throw new ResourceException(IResourceStatus.FAILED_SETTING_CHARSET, resourcePath, message, e);
 	}
 
+	/**
+	 * Schedules a check whether the given project has an explicit encoding.
+	 */
+	public void validateProjectEncoding(IProject project) {
+		encodingValidation.scheduleProjectValidation(project);
+	}
+
 	@Override
 	public void shutdown(IProgressMonitor monitor) {
 		if (job != null) {
 			job.shutDown();
+		}
+		if (encodingValidation != null) {
+			encodingValidation.cancel();
 		}
 		InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES)
 				.removePreferenceChangeListener(preferenceChangeListener);
@@ -584,18 +595,19 @@ public class CharsetManager implements IManager {
 	@Override
 	public void startup(IProgressMonitor monitor) {
 		job = new CharsetManagerJob();
+		encodingValidation = new ValidateProjectEncoding(workspace);
 		resourceChangeListener = new ResourceChangeListener();
 		workspace.addResourceChangeListener(resourceChangeListener, IResourceChangeEvent.POST_CHANGE);
 		charsetListener = new CharsetDeltaJob(workspace);
 		charsetListener.startup();
-		ValidateProjectEncoding.scheduleWorkspaceValidation(workspace);
+		encodingValidation.scheduleWorkspaceValidation();
 		initPreferenceChangeListener();
 	}
 
 	private void initPreferenceChangeListener() {
 		preferenceChangeListener = event -> {
 			if (ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY.equals(event.getKey())) {
-				ValidateProjectEncoding.scheduleWorkspaceValidation(workspace);
+				encodingValidation.scheduleWorkspaceValidation();
 			}
 		};
 

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Project.java
@@ -1214,7 +1214,7 @@ public class Project extends Container implements IProject {
 			monitor.done();
 		}
 		if (!encodingWritten) {
-			ValidateProjectEncoding.scheduleProjectValidation((Workspace) getWorkspace(), this);
+			workspace.getCharsetManager().validateProjectEncoding(this);
 		}
 	}
 

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ValidateProjectEncoding.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/ValidateProjectEncoding.java
@@ -23,6 +23,7 @@ import org.eclipse.osgi.util.NLS;
 
 /**
  * Reports warning markers on projects without an explicit encoding setting.
+ * Requests are collected and handled together in a single job run.
  */
 public class ValidateProjectEncoding extends InternalWorkspaceJob {
 
@@ -37,29 +38,49 @@ public class ValidateProjectEncoding extends InternalWorkspaceJob {
 	 */
 	public static final int SEVERITY_IGNORE = -1;
 
-	public static void scheduleWorkspaceValidation(Workspace workspace) {
-		IProject[] projects = workspace.getRoot().getProjects();
-		ValidateProjectEncoding validateProjectEncoding = new ValidateProjectEncoding(workspace, projects);
-		validateProjectEncoding.setRule(workspace.getRoot());
-		validateProjectEncoding.schedule();
-	}
+	private final Workspace workspace;
+	private final Set<IProject> pendingProjects = new LinkedHashSet<>();
+	private boolean validateAllProjects;
 
-	public static void scheduleProjectValidation(Workspace workspace, IProject project) {
-		// schedule a job only if marker state would change
-		boolean shouldScheduleValidation = shouldScheduleValidation(project);
-		if (shouldScheduleValidation) {
-			ValidateProjectEncoding validateProjectEncoding = new ValidateProjectEncoding(workspace, project);
-			validateProjectEncoding.setRule(project);
-			validateProjectEncoding.schedule();
-		}
-	}
-
-	private final IProject[] projects;
-
-	private ValidateProjectEncoding(Workspace workspace, IProject... projects) {
+	ValidateProjectEncoding(Workspace workspace) {
 		super(Messages.resources_checkExplicitEncoding_jobName, workspace);
+		this.workspace = workspace;
 		setSystem(true);
-		this.projects = projects;
+		setRule(workspace.getRoot());
+	}
+
+	/**
+	 * Validates all projects of the workspace in the next run of this job.
+	 */
+	public void scheduleWorkspaceValidation() {
+		synchronized (pendingProjects) {
+			validateAllProjects = true;
+		}
+		schedule();
+	}
+
+	/**
+	 * Validates the given project in the next run of this job, unless its marker
+	 * state already matches its encoding setting.
+	 */
+	public void scheduleProjectValidation(IProject project) {
+		if (!shouldScheduleValidation(project)) {
+			return;
+		}
+		synchronized (pendingProjects) {
+			pendingProjects.add(project);
+		}
+		schedule();
+	}
+
+	private IProject[] takePendingProjects() {
+		synchronized (pendingProjects) {
+			IProject[] projects = validateAllProjects ? workspace.getRoot().getProjects()
+					: pendingProjects.toArray(new IProject[0]);
+			validateAllProjects = false;
+			pendingProjects.clear();
+			return projects;
+		}
 	}
 
 	@Override
@@ -72,6 +93,7 @@ public class ValidateProjectEncoding extends InternalWorkspaceJob {
 		if (monitor.isCanceled()) {
 			return Status.CANCEL_STATUS;
 		}
+		IProject[] projects = takePendingProjects();
 		SubMonitor subMonitor = SubMonitor.convert(monitor, projects.length);
 		for (IProject project : projects) {
 			subMonitor.checkCanceled();

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/resources/ProjectEncodingTest.java
@@ -14,10 +14,12 @@
 package org.eclipse.core.tests.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createInFileSystem;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createInWorkspace;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
 import static org.eclipse.core.tests.resources.ResourceTestUtil.createUniqueString;
-import static org.eclipse.core.tests.resources.ResourceTestUtil.waitForBuild;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
@@ -28,9 +30,12 @@ import org.eclipse.core.internal.utils.Messages;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
@@ -151,6 +156,51 @@ public class ProjectEncodingTest {
 		thenProjectHasNoEncodingMarker();
 	}
 
+	@Test
+	public void test_TwoProjectsOpenedWithoutEncoding_ValidatedInOneJobRun_EachProjectHasMarker()
+			throws Exception {
+		givenPreferenceIsSetTo(IMarker.SEVERITY_WARNING);
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IProject first = workspace.getRoot().getProject(createUniqueString());
+		IProject second = workspace.getRoot().getProject(createUniqueString());
+		createProjectWithContentOnDisk(first);
+		createProjectWithContentOnDisk(second);
+
+		AtomicInteger validationRuns = new AtomicInteger();
+		JobChangeAdapter validationRunCounter = new JobChangeAdapter() {
+			@Override
+			public void running(IJobChangeEvent event) {
+				if (event.getJob().belongsTo(ValidateProjectEncoding.class)) {
+					validationRuns.incrementAndGet();
+				}
+			}
+		};
+		Job.getJobManager().addJobChangeListener(validationRunCounter);
+		try {
+			// open both projects in one workspace operation, like a mass import does
+			workspace.run(monitor -> {
+				first.open(monitor);
+				second.open(monitor);
+			}, workspace.getRoot(), IWorkspace.AVOID_UPDATE, null);
+			waitForEncodingValidation();
+		} finally {
+			Job.getJobManager().removeJobChangeListener(validationRunCounter);
+		}
+
+		assertThat(validationRuns).as("encoding validation job runs").hasValue(1);
+		IProjectMatcher.assertThat(first).hasEncodingMarkerOfSeverity(IMarker.SEVERITY_WARNING);
+		IProjectMatcher.assertThat(second).hasEncodingMarkerOfSeverity(IMarker.SEVERITY_WARNING);
+	}
+
+	/**
+	 * Creates a closed project whose location already has content, so that
+	 * opening it does not write a default encoding.
+	 */
+	private static void createProjectWithContentOnDisk(IProject project) throws Exception {
+		createInFileSystem(project.getFile("content.txt"));
+		project.create(null);
+	}
+
 	private void whenPreferenceIsChangedTo(int severity) throws Exception {
 		givenPreferenceIsSetTo(severity);
 	}
@@ -159,6 +209,10 @@ public class ProjectEncodingTest {
 		IEclipsePreferences node = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
 		node.putInt(ResourcesPlugin.PREF_MISSING_ENCODING_MARKER_SEVERITY, value);
 		node.flush();
+		waitForEncodingValidation();
+	}
+
+	private static void waitForEncodingValidation() throws InterruptedException {
 		Job.getJobManager().wakeUp(ValidateProjectEncoding.class);
 		Job.getJobManager().join(ValidateProjectEncoding.class, createTestMonitor());
 	}
@@ -170,12 +224,12 @@ public class ProjectEncodingTest {
 
 	private void whenProjectSpecificEncodingWasRemoved() throws Exception {
 		project.setDefaultCharset(null, null);
-		buildAndWaitForBuildFinish();
+		waitForEncodingValidation();
 	}
 
 	private void whenProjectSpecificEncodingWasSet() throws Exception {
 		project.setDefaultCharset("UTF-8", null);
-		buildAndWaitForBuildFinish();
+		waitForEncodingValidation();
 	}
 
 	private void thenProjectHasNoEncodingMarker() throws Exception {
@@ -217,10 +271,6 @@ public class ProjectEncodingTest {
 			return NLS.bind(Messages.resources_checkExplicitEncoding_problemText, actual.getName());
 		}
 
-	}
-
-	private void buildAndWaitForBuildFinish() {
-		waitForBuild();
 	}
 
 }


### PR DESCRIPTION
Opening many projects at once, for example through Smart Import of a large aggregator, scheduled one "Checking project encoding" job per project. Inside a workspace operation that holds the root rule, all of these jobs were queued and released in one burst when the operation ended, and thread dumps of a frozen IDE showed dozens of them contending for the workspace lock together with the import jobs.

ValidateProjectEncoding is now a single job per workspace, owned by the CharsetManager. Requests add the project to a pending set and schedule the job. While the job waits for the lock held by the operation, further requests only extend the pending set, so a burst of project opens is validated in one run. A workspace-wide request covers all projects in the next run instead of creating a separate job. The job family, its scheduling without delay, and the marker results per project are unchanged.

A new test in ProjectEncodingTest opens two projects inside one root-rule operation and checks that a single run produces the expected marker on each. The existing tests in that class now join the validation job family explicitly instead of relying on the auto build running after it. ProjectEncodingTest, CharsetTest and IProjectTest pass locally.