### PR TITLE
Delete read-only symbolic links on Windows with Java 25

### DIFF
--- a/resources/bundles/org.eclipse.core.filesystem/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.filesystem/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.filesystem; singleton:=true
-Bundle-Version: 1.11.500.qualifier
+Bundle-Version: 1.11.600.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)"
 Export-Package: org.eclipse.core.filesystem;uses:="org.eclipse.core.runtime",

--- a/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFile.java
+++ b/resources/bundles/org.eclipse.core.filesystem/src/org/eclipse/core/internal/filesystem/local/LocalFile.java
@@ -32,6 +32,7 @@ import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -299,6 +300,17 @@ public class LocalFile extends FileStore {
 				/* keepAliveTime */ 1, TimeUnit.MINUTES); // pool terminates 1 thread per
 	}
 
+	private static void clearWindowsReadOnlyAttribute(Path path) {
+		if (!OS.isWindows()) {
+			return;
+		}
+		try {
+			Files.setAttribute(path, "dos:readonly", Boolean.FALSE, LinkOption.NOFOLLOW_LINKS); //$NON-NLS-1$
+		} catch (IOException | UnsupportedOperationException e) {
+			// deletion is retried anyway and reports the original failure
+		}
+	}
+
 	/**
 	* Deletes the given file recursively, adding failure info to
 	* the provided status object.  The filePath is passed as a parameter
@@ -317,14 +329,10 @@ public class LocalFile extends FileStore {
 				infMonitor.worked();
 				return Status.OK_STATUS;
 			} catch (AccessDeniedException e) {
-				// If the file is read only, it can't be deleted via Files.deleteIfExists()
-				// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=500306
-				// Since Java 25, just calling File#delete() is not sufficient anymore on Windows
-				// but the read-only state has to be cleared explicitly,
-				// see https://bugs.openjdk.org/browse/JDK-8355954
-				if (OS.isWindows()) {
-					target.setWritable(true);
-				}
+				// Read-only files can't be deleted via Files.deleteIfExists() (bug 500306) and
+				// since Java 25 File#delete() no longer clears the flag on Windows (JDK-8355954).
+				// Clear it on the path itself, File#setWritable() would follow symbolic links.
+				clearWindowsReadOnlyAttribute(target.toPath());
 				if (target.delete()) {
 					infMonitor.worked();
 					return Status.OK_STATUS;

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/SymlinkTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/filesystem/SymlinkTest.java
@@ -221,33 +221,25 @@ public class SymlinkTest {
 
 		IFileInfo[] infos = baseStore.childInfos(EFS.NONE, getMonitor());
 		assertThat(infos).hasSize(2);
+		// FIXME bug: putInfo neither sets attributes nor throws an exception for broken
+		// symbolic links. Once fixed, replace the try/catch blocks below with assertThrows
+		// and assert that the read-only attribute and the last modified time were set.
 		i1.setAttribute(EFS.ATTRIBUTE_READ_ONLY, true);
-		boolean exceptionThrown = false;
 		try {
 			l1.putInfo(i1, EFS.SET_ATTRIBUTES, getMonitor());
 		} catch (CoreException ce) {
-			exceptionThrown = true;
+			// ignored until the FIXME above is resolved
 		}
 		i1 = l1.fetchInfo();
-		boolean fixMeFixed = false;
-		if (fixMeFixed) {
-			//FIXME bug: putInfo neither sets attributes nor throws an exception for broken symbolic links
-			assertTrue(exceptionThrown);
-			assertTrue(i1.getAttribute(EFS.ATTRIBUTE_READ_ONLY));
-		}
 		assertEquals(SYMLINKS_ARE_FIRST_CLASS_FILES_OR_DIRECTORIES, i1.exists());
 
 		i1.setLastModified(12345);
-		exceptionThrown = false;
 		try {
 			l1.putInfo(i1, EFS.SET_LAST_MODIFIED, getMonitor());
 		} catch (CoreException ce) {
-			exceptionThrown = true;
+			// ignored until the FIXME above is resolved
 		}
 		i1 = l1.fetchInfo();
-		//FIXME bug: putInfo neither sets attributes nor throws an exception for broken symbolic links
-		//assertTrue(exceptionThrown);
-		//assertEquals(i1.getLastModified(), 12345);
 		assertEquals(SYMLINKS_ARE_FIRST_CLASS_FILES_OR_DIRECTORIES, i1.exists());
 
 		l1.delete(EFS.NONE, getMonitor());


### PR DESCRIPTION
On Windows with Java 25, deleting a read-only symbolic link through EFS fails. File#delete() no longer strips the read-only attribute since JDK-8355954, and the existing workaround via File#setWritable(true) follows the link, so it either clears the attribute on the target instead of the link or fails for broken and recursive links. This is why SymlinkTest#testRecursiveSymlink fails on the Windows GitHub runners.

The fix clears the DOS read-only attribute on the path itself with NOFOLLOW_LINKS before retrying the deletion. The dead fixMeFixed block in testRecursiveSymlink is removed as well.

Verified locally on Linux by building both bundles in one reactor and running SymlinkTest. The Windows behaviour itself can only be confirmed by CI.