### PR TITLE
Fix Invalid thread access in ConsoleZoomHandler during shutdown

### DIFF
--- a/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.console; singleton:=true
-Bundle-Version: 3.17.100.qualifier
+Bundle-Version: 3.17.200.qualifier
 Bundle-Activator: org.eclipse.ui.console.ConsolePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleZoomHandler.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleZoomHandler.java
@@ -33,6 +33,7 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.console.IConsoleConstants;
@@ -152,7 +153,7 @@ public class ConsoleZoomHandler extends AbstractHandler implements IExecutableEx
 					textConsole.addPropertyChangeListener(FONT_ENFORCER);
 					ZoomState state = sZoomByType.get(typeKey(textConsole));
 					if (state != null) {
-						Display.getDefault().asyncExec(() -> applyHeight(textConsole, state.height()));
+						runOnDisplayIfAvailable(() -> applyHeight(textConsole, state.height()));
 					}
 				}
 			}
@@ -163,11 +164,27 @@ public class ConsoleZoomHandler extends AbstractHandler implements IExecutableEx
 			for (IConsole console : consoles) {
 				if (console instanceof TextConsole textConsole) {
 					textConsole.removePropertyChangeListener(FONT_ENFORCER);
-					Display.getDefault().asyncExec(() -> disposeZoomFonts(textConsole));
+					runOnDisplayIfAvailable(() -> disposeZoomFonts(textConsole));
 				}
 			}
 		}
 	};
+
+	/**
+	 * Runs the runnable on the workbench display, or skips it if no display
+	 * is available (e.g. during shutdown).
+	 * @param runnable the UI work to perform
+	 */
+	private static void runOnDisplayIfAvailable(Runnable runnable) {
+		if (!PlatformUI.isWorkbenchRunning()) {
+			return;
+		}
+		Display display = PlatformUI.getWorkbench().getDisplay();
+		if (display == null || display.isDisposed()) {
+			return;
+		}
+		display.asyncExec(runnable);
+	}
 
 	/**
 	 * Registers {@link #ZOOM_FONT_LISTENER} and loads any persisted zoom state.
@@ -434,7 +451,11 @@ public class ConsoleZoomHandler extends AbstractHandler implements IExecutableEx
 	private static void disposeZoomFonts(TextConsole textConsole) {
 		List<Font> oldFonts = fontsMap.remove(textConsole);
 		if (oldFonts != null && !oldFonts.isEmpty()) {
-			Display.getDefault().timerExec(100, () -> {
+			Display display = Display.getCurrent();
+			if (display == null || display.isDisposed()) {
+				return;
+			}
+			display.timerExec(100, () -> {
 				for (Font font : oldFonts) {
 					if (font != null && !font.isDisposed()) {
 						font.dispose();


### PR DESCRIPTION
Display.getDefault() could be called from a non-UI thread when console add/remove notifications fire during workbench shutdown, throwing SWTException.

Fixes : https://github.com/eclipse-platform/eclipse.platform/issues/2911