### PR TITLE
Fix clipped text on Launch Config dialog buttons

### DIFF
--- a/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupViewer.java
+++ b/debug/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationTabGroupViewer.java
@@ -276,7 +276,6 @@ public class LaunchConfigurationTabGroupViewer {
 		fShowCommandLineButton = SWTFactory.createPushButton(buttonComp,
 				LaunchConfigurationsMessages.LaunchConfigurationDialog_ShowCommandLine, null,
 				GridData.HORIZONTAL_ALIGN_BEGINNING);
-		fShowCommandLineButton.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false));
 		fShowCommandLineButton.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent evt) {
@@ -306,6 +305,11 @@ public class LaunchConfigurationTabGroupViewer {
 				}
 			}
 		});
+
+		((GridData) fShowCommandLineButton.getLayoutData()).widthHint = SWT.DEFAULT;
+		((GridData) fRevertButton.getLayoutData()).widthHint = SWT.DEFAULT;
+		((GridData) fApplyButton.getLayoutData()).widthHint = SWT.DEFAULT;
+
 		Dialog.applyDialogFont(parent);
 	}
 


### PR DESCRIPTION
Fixes clipped text for Revert & Apply buttons for windows.

See https://github.com/eclipse-platform/eclipse.platform/pull/2788#pullrequestreview-4949762872

<img width="583" height="115" alt="Screenshot 2026-09-11 at 1 36 21 PM" src="https://github.com/user-attachments/assets/edc075f1-ec8c-4fa2-a54b-c3bb6f8ec7f5" />
