### PR TITLE
Add Compare with Clipboard action to Console

### DIFF
--- a/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.ui.console/META-INF/MANIFEST.MF
@@ -40,3 +40,5 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.eclipse.ui.console
 Require-Capability: eclipse.swt;filter:="(image.format=svg)"
+Import-Package: org.eclipse.compare;resolution:=optional,
+ org.eclipse.compare.structuremergeviewer;resolution:=optional

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsolePage.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsolePage.java
@@ -48,6 +48,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.console.actions.ClearOutputAction;
 import org.eclipse.ui.console.actions.TextViewerAction;
+import org.eclipse.ui.internal.console.CompareConsoleWithClipboard;
 import org.eclipse.ui.internal.console.ConsoleMessages;
 import org.eclipse.ui.internal.console.ConsoleResourceBundleMessages;
 import org.eclipse.ui.internal.console.FollowHyperlinkAction;
@@ -366,6 +367,9 @@ public class TextConsolePage implements IPageBookViewPage, IPropertyChangeListen
 		menuManager.add(fGlobalActions.get(ITextEditorActionConstants.FIND_NEXT));
 		menuManager.add(fGlobalActions.get(ITextEditorActionConstants.FIND_PREVIOUS));
 		menuManager.add(new FollowHyperlinkAction(fViewer.getHyperlink()));
+		if (CompareConsoleWithClipboard.isAvailable()) {
+			menuManager.add(new CompareConsoleWithClipboard(fViewer));
+		}
 		menuManager.add(fClearOutputAction);
 
 		menuManager.add(new Separator(IWorkbenchActionConstants.MB_ADDITIONS));

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/CompareConsoleWithClipboard.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/CompareConsoleWithClipboard.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.ui.internal.console;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.compare.CompareConfiguration;
+import org.eclipse.compare.CompareEditorInput;
+import org.eclipse.compare.CompareUI;
+import org.eclipse.compare.IEncodedStreamContentAccessor;
+import org.eclipse.compare.ITypedElement;
+import org.eclipse.compare.structuremergeviewer.DiffNode;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.swt.dnd.Clipboard;
+import org.eclipse.swt.dnd.TextTransfer;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.console.TextConsoleViewer;
+
+public class CompareConsoleWithClipboard extends Action {
+
+	private final TextConsoleViewer console;
+	public CompareConsoleWithClipboard(TextConsoleViewer consoleView) {
+		super(ConsoleMessages.CompareConsoleWithClipboard_0);
+		this.console = consoleView;
+		setToolTipText(ConsoleMessages.CompareConsoleWithClipboard_6);
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IConsoleHelpContextIds.CONSOLE_COMPARE_ACTION);
+	}
+
+	/**
+	 * @see org.eclipse.jface.action.IAction#run()
+	 */
+	@Override
+	public void run() {
+		ISelection selection = console.getSelection();
+		if (selection instanceof ITextSelection textSelection) {
+			String selectedText = textSelection.getText();
+			if (selectedText.isEmpty()) {
+				selectedText = console.getDocument().get();
+			}
+			compareWithClipboard(ConsoleMessages.CompareConsoleWithClipboard_1, selectedText);
+		}
+	}
+
+	private static void compareWithClipboard(String leftLabel, String content) {
+		Object clipboardContents = getClipboard();
+		if (!(clipboardContents instanceof String clipboardText)) {
+			MessageDialog.openInformation(Display.getDefault().getActiveShell(), ConsoleMessages.CompareConsoleWithClipboard_2,
+					ConsoleMessages.CompareConsoleWithClipboard_3);
+			return;
+		}
+
+		class StringTypedElement implements ITypedElement, IEncodedStreamContentAccessor {
+			private final String name;
+			private final String text;
+
+			StringTypedElement(String name, String text) {
+				this.name = name;
+				this.text = text;
+			}
+
+			@Override
+			public String getName() {
+				return name;
+			}
+
+			@Override
+			public Image getImage() {
+				return null;
+			}
+
+			@Override
+			public String getType() {
+				return ITypedElement.TEXT_TYPE;
+			}
+
+			@Override
+			public String getCharset() {
+				return StandardCharsets.UTF_8.name();
+			}
+
+			@Override
+			public InputStream getContents() {
+				return new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+			}
+		}
+
+		CompareConfiguration configuration = new CompareConfiguration();
+		configuration.setLeftLabel(leftLabel);
+		configuration.setRightLabel(ConsoleMessages.CompareConsoleWithClipboard_4);
+		configuration.setLeftEditable(false);
+		configuration.setRightEditable(false);
+
+		CompareEditorInput input = new CompareEditorInput(configuration) {
+			@Override
+			protected Object prepareInput(IProgressMonitor monitor)
+					throws InvocationTargetException, InterruptedException {
+				return new DiffNode(new StringTypedElement(leftLabel, content),
+						new StringTypedElement(ConsoleMessages.CompareConsoleWithClipboard_4, clipboardText));
+			}
+		};
+
+		input.setTitle(ConsoleMessages.CompareConsoleWithClipboard_5);
+		CompareUI.openCompareEditor(input);
+	}
+
+	private static Object getClipboard() {
+		Clipboard clipboard = new Clipboard(Display.getDefault());
+		try {
+			return clipboard.getContents(TextTransfer.getInstance());
+		} finally {
+			clipboard.dispose();
+		}
+	}
+
+	public static boolean isAvailable() {
+		return Platform.getBundle("org.eclipse.compare") != null; //$NON-NLS-1$
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return console.getDocument().getLength() > 0;
+	}
+}
+

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleMessages.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2014 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,6 @@ public class ConsoleMessages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.ui.internal.console.ConsoleMessages";//$NON-NLS-1$
 
 	public static String AbstractConsole_0;
-
 	public static String ConsoleDropDownAction_0;
 	public static String ConsoleDropDownAction_1;
 
@@ -80,4 +79,12 @@ public class ConsoleMessages extends NLS {
 	public static String PatternMatchListenerExtension_5;
 
 	public static String UpdatingConsoleState;
+
+	public static String CompareConsoleWithClipboard_0;
+	public static String CompareConsoleWithClipboard_1;
+	public static String CompareConsoleWithClipboard_2;
+	public static String CompareConsoleWithClipboard_3;
+	public static String CompareConsoleWithClipboard_4;
+	public static String CompareConsoleWithClipboard_5;
+	public static String CompareConsoleWithClipboard_6;
 }

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleMessages.properties
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2014 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,14 @@
 ###############################################################################
 
 AbstractConsole_0=Exception occurred during console property change notification.
+
+CompareConsoleWithClipboard_0=Compare with Clipboard
+CompareConsoleWithClipboard_1=Console
+CompareConsoleWithClipboard_2=Comparison Failed
+CompareConsoleWithClipboard_3=Clipboard does not contain text.
+CompareConsoleWithClipboard_4=Clipboard
+CompareConsoleWithClipboard_5=Compare with Clipboard
+CompareConsoleWithClipboard_6=Compare console output with clipboard content
 
 ConsoleDropDownAction_0=Select Console
 ConsoleDropDownAction_1=Display Selected Console

--- a/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/IConsoleHelpContextIds.java
+++ b/debug/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/IConsoleHelpContextIds.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -42,7 +42,7 @@ public interface IConsoleHelpContextIds {
 	String CONSOLE_OPEN_CONSOLE_ACTION = PREFIX + "console_open_console_action_context"; //$NON-NLS-1$
 	String CONSOLE_DISPLAY_CONSOLE_ACTION = PREFIX + "console_display_console_action"; //$NON-NLS-1$
 	String CONSOLE_PIN_CONSOLE_ACITON = PREFIX + "console_pin_console_action"; //$NON-NLS-1$
-
+	String CONSOLE_COMPARE_ACTION = PREFIX + "console_compare_action_context"; //$NON-NLS-1$
 	// Views
 	String CONSOLE_VIEW = PREFIX + "console_view_context"; //$NON-NLS-1$
 


### PR DESCRIPTION
Adds a Compare with Clipboard action to the Console view, allowing users to compare console output directly with text currently available in the clipboard using Compare Editor. This simplifies a common debugging and development workflow by eliminating the need to manually copy console output into a separate editor or comparison tool. Users can quickly identify differences between console output and expected or reference content, making it easier to investigate test failures, verify generated output, and diagnose unexpected results

<img width="692" height="391" alt="image" src="https://github.com/user-attachments/assets/0085faa6-d0b9-4383-b10c-ce25ee866378" />

<img width="1080" height="810" alt="cm" src="https://github.com/user-attachments/assets/574e870d-6dbc-46b6-9a2c-919244121195" />
